### PR TITLE
fix configs cannot be loaded correctly

### DIFF
--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -15,7 +15,8 @@ namespace Shadowsocks.Model
         public bool shareOverLan;
         public bool isDefault;
 
-        private static string CONFIG_FILE = "gui-config.json";
+        private static string EXE_PATH = Application.StartupPath + "\\";
+        private static string CONFIG_FILE = EXE_PATH + "gui-config.json";
 
         public Server GetCurrentServer()
         {


### PR DESCRIPTION
I don't understand why you removed kookxiang's config path fix code in commit "lint code". While Shadowsocks client starts on boot, the work directory seems to be C:\Windows\System32. Config file can't be loaded from an incorrect directory.
