### PR TITLE
修改socks5协议连接建立成功回复发送时间

### DIFF
--- a/shadowsocks-csharp/Controller/Service/TCPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/TCPRelay.cs
@@ -74,7 +74,7 @@ namespace Shadowsocks.Controller
         private bool connectionShutdown = false;
         private bool remoteShutdown = false;
         private bool closed = false;
-        
+
         private object encryptionLock = new object();
         private object decryptionLock = new object();
 
@@ -222,14 +222,13 @@ namespace Shadowsocks.Controller
             try
             {
                 int bytesRead = connection.EndReceive(ar);
-                
+
                 if (bytesRead >= 3)
                 {
                     command = connetionRecvBuffer[1];
                     if (command == 1)
                     {
-                        byte[] response = { 5, 0, 0, 1, 0, 0, 0, 0, 0, 0 };
-                        connection.BeginSend(response, 0, response.Length, 0, new AsyncCallback(ResponseCallback), null);
+                        StartConnect();
                     }
                     else if (command == 3)
                     {
@@ -312,7 +311,7 @@ namespace Shadowsocks.Controller
             {
                 connection.EndSend(ar);
 
-                StartConnect();
+                StartPipe();
             }
 
             catch (Exception e)
@@ -326,7 +325,7 @@ namespace Shadowsocks.Controller
         {
             public Server Server;
 
-            public ServerTimer(int p) :base(p)
+            public ServerTimer(int p) : base(p)
             {
             }
         }
@@ -432,7 +431,8 @@ namespace Shadowsocks.Controller
                     strategy.UpdateLatency(server, latency);
                 }
 
-                StartPipe();
+                byte[] response = { 5, 0, 0, 1, 0, 0, 0, 0, 0, 0 };
+                connection.BeginSend(response, 0, response.Length, 0, new AsyncCallback(ResponseCallback), null);
             }
             catch (ArgumentException)
             {


### PR DESCRIPTION
原始的是 socks5 收到tcp代理请求立刻回复已成功连接到远程主机，现在改为只有建立了到远程ss服务器的连接后才回复连接已建立。

主要使用 TcpRoute 自动选择最快线路时使用 ss 作为后端，发现 ss 到目的网站的连接建立速度居然达到了30毫秒级。检查代码发现 ss 收到连接请求立刻回复已建立连接，透明测速失败...

https://github.com/GameXG/TcpRoute