### PR TITLE
启用系统代理时禁用“自动检测设置”，并且无必要时不清除原有代理服务器设置。

### DIFF
--- a/shadowsocks-csharp/Controller/System/SystemProxy.cs
+++ b/shadowsocks-csharp/Controller/System/SystemProxy.cs
@@ -55,7 +55,9 @@ namespace Shadowsocks.Controller
                         else
                             pacUrl = "http://127.0.0.1:" + config.localPort.ToString() + "/pac?t=" + GetTimestamp(DateTime.Now);
                         registry.SetValue("ProxyEnable", 0);
-                        //registry.SetValue("ProxyServer", "");         //Unnecessary
+                        var readProxyServer = registry.GetValue("ProxyServer");
+                        if (readProxyServer != null && readProxyServer.Equals("127.0.0.1:" + config.localPort.ToString()))
+                            registry.SetValue("ProxyServer", "");
                         registry.SetValue("AutoConfigURL", pacUrl);
                     }
                 }

--- a/shadowsocks-csharp/Controller/System/SystemProxy.cs
+++ b/shadowsocks-csharp/Controller/System/SystemProxy.cs
@@ -55,16 +55,21 @@ namespace Shadowsocks.Controller
                         else
                             pacUrl = "http://127.0.0.1:" + config.localPort.ToString() + "/pac?t=" + GetTimestamp(DateTime.Now);
                         registry.SetValue("ProxyEnable", 0);
-                        registry.SetValue("ProxyServer", "");
+                        //registry.SetValue("ProxyServer", "");         //Unnecessary
                         registry.SetValue("AutoConfigURL", pacUrl);
                     }
                 }
                 else
                 {
                     registry.SetValue("ProxyEnable", 0);
-                    registry.SetValue("ProxyServer", "");
+                    if (global)
+                    {
+                        registry.SetValue("ProxyServer", "");
+                    }
                     registry.SetValue("AutoConfigURL", "");
                 }
+                //Set AutoDetectProxy Off
+                IEAutoDetectProxy(false);
                 SystemProxy.NotifyIE();
                 //Must Notify IE first, or the connections do not chanage
                 CopyProxySettingFromLan();
@@ -105,6 +110,31 @@ namespace Shadowsocks.Controller
         private static String GetTimestamp(DateTime value)
         {
             return value.ToString("yyyyMMddHHmmssffff");
+        }
+
+        /// <summary>
+        /// Checks or unchecks the IE Options Connection setting of "Automatically detect Proxy"
+        /// </summary>
+        /// <param name="set">Provide 'true' if you want to check the 'Automatically detect Proxy' check box. To uncheck, pass 'false'</param>
+        private static void IEAutoDetectProxy(bool set)
+        {
+            RegistryKey registry =
+                Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings\\Connections",
+                    true);
+            byte[] defConnection = (byte[])registry.GetValue("DefaultConnectionSettings");
+            byte[] savedLegacySetting = (byte[])registry.GetValue("SavedLegacySettings");
+            if (set)
+            {
+                defConnection[8] = Convert.ToByte(defConnection[8] & 8);
+                savedLegacySetting[8] = Convert.ToByte(savedLegacySetting[8] & 8);
+            }
+            else
+            {
+                defConnection[8] = Convert.ToByte(defConnection[8] & ~8);
+                savedLegacySetting[8] = Convert.ToByte(savedLegacySetting[8] & ~8);
+            }
+            registry.SetValue("DefaultConnectionSettings", defConnection);
+            registry.SetValue("SavedLegacySettings", savedLegacySetting);
         }
     }
 }


### PR DESCRIPTION
在公司内部有部署WPAD代理自动发现时，必须禁用“自动检测设置”，指定的PAC才会生效。否则会优先使用wpad.dat的规则文件。
另外，IE原来设置了个人的（或公司内部的）代理服务器，如果临时用下SS的PAC，没必须把代理服务器也清除。这样在取消SS的启用系统代理之后，不需要再重新填写一遍个人代理地址和端口。