### PR TITLE
Add availability statistics service and a simple strategy

### DIFF
--- a/shadowsocks-csharp/Controller/Service/AvailabilityStatistics.cs
+++ b/shadowsocks-csharp/Controller/Service/AvailabilityStatistics.cs
@@ -15,7 +15,7 @@ namespace Shadowsocks.Controller
         private static readonly string Delimiter = ",";
         private static readonly int Timeout = 500;
         private static readonly int Repeat = 4; //repeat times every evaluation
-        private static readonly int Interval = 60 * 60 * 1000;  //evaluate proxies every 60 minutes
+        private static readonly int Interval = 10 * 60 * 1000;  //evaluate proxies every 15 minutes
         private Timer timer = null;
         private State state = null;
         private List<Server> servers;

--- a/shadowsocks-csharp/Controller/Service/AvailabilityStatistics.cs
+++ b/shadowsocks-csharp/Controller/Service/AvailabilityStatistics.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Threading;
+using Shadowsocks.Model;
+using System.Reflection;
+
+namespace Shadowsocks.Controller
+{
+    class AvailabilityStatistics
+    {
+        private static readonly string StatisticsFilesName = "shadowsocks.availability.csv";
+        private static readonly string Delimiter = ",";
+        private static readonly int Timeout = 500;
+        private static readonly int Repeat = 4; //repeat times every evaluation
+        private static readonly int Interval = 60 * 60 * 1000;  //evaluate proxies every 60 minutes
+        private Timer timer = null;
+        private State state = null;
+        private List<Server> servers;
+
+        public static string AvailabilityStatisticsFile;
+
+        //static constructor to initialize every public static fields before refereced
+        static AvailabilityStatistics()
+        {
+            string temppath = Path.GetTempPath();
+            AvailabilityStatisticsFile = Path.Combine(temppath, StatisticsFilesName);
+        }
+
+        public bool Set(bool enabled)
+        {
+            try
+            {
+                if (enabled)
+                {
+                    if (timer?.Change(0, Interval) == null)
+                    {
+                        state = new State();
+                        timer = new Timer(Evaluate, state, 0, Interval);
+                    }
+                }
+                else
+                {
+                    timer?.Dispose();
+                }
+                return true;
+            }
+            catch (Exception e)
+            {
+                Logging.LogUsefulException(e);
+                return false;
+            }
+        }
+
+        private void Evaluate(object obj)
+        {
+            Ping ping = new Ping();
+            State state = (State) obj;
+            foreach (var server in servers)
+            {
+                Logging.Debug("eveluating " + server.FriendlyName());
+                foreach (var _ in Enumerable.Range(0, Repeat))
+                {
+                    //TODO: do simple analyze of data to provide friendly message, like package loss.
+                    string timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                    //ICMP echo. we can also set options and special bytes
+                    //seems no need to use SendPingAsync
+                    PingReply reply = ping.Send(server.server, Timeout);
+                    state.data = new List<KeyValuePair<string, string>>();
+                    state.data.Add(new KeyValuePair<string, string>("Timestamp", timestamp));
+                    state.data.Add(new KeyValuePair<string, string>("Server", server.FriendlyName()));
+                    state.data.Add(new KeyValuePair<string, string>("Status", reply.Status.ToString()));
+                    state.data.Add(new KeyValuePair<string, string>("RoundtripTime", reply.RoundtripTime.ToString()));
+                    //state.data.Add(new KeyValuePair<string, string>("data", reply.Buffer.ToString())); // The data of reply
+                    Append(state.data);
+                }
+            }
+        }
+
+        private static void Append(List<KeyValuePair<string, string>> data)
+        {
+            string dataLine = string.Join(Delimiter, data.Select(kv => kv.Value).ToArray());
+            string[] lines;
+            if (!File.Exists(AvailabilityStatisticsFile))
+            {
+                string headerLine = string.Join(Delimiter, data.Select(kv => kv.Key).ToArray());
+                lines = new string[] { headerLine, dataLine };
+            }
+            else
+            {
+                lines = new string[] { dataLine };
+            }
+            File.AppendAllLines(AvailabilityStatisticsFile, lines);
+        }
+
+        internal void UpdateConfiguration(Configuration _config)
+        {
+            Set(_config.availabilityStatistics);
+            servers = _config.configs;
+        }
+
+        private class State
+        {
+            public List<KeyValuePair<string, string>> data = new List<KeyValuePair<string, string>>();
+        }
+    }
+}

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -25,6 +25,7 @@ namespace Shadowsocks.Controller
         private StrategyManager _strategyManager;
         private PolipoRunner polipoRunner;
         private GFWListUpdater gfwListUpdater;
+        private AvailabilityStatistics _availabilityStatics;
         private bool stopped = false;
 
         private bool _systemProxyIsDirty = false;
@@ -246,6 +247,16 @@ namespace Shadowsocks.Controller
             }
         }
 
+        public void ToggleAvailabilityStatistics(bool enabled)
+        {
+            if (_availabilityStatics != null)
+            {
+                _availabilityStatics.Set(enabled);
+                _config.availabilityStatistics = enabled;
+                SaveConfig(_config);
+            }
+        }
+
         public void SavePACUrl(string pacUrl)
         {
             _config.pacUrl = pacUrl;
@@ -293,6 +304,12 @@ namespace Shadowsocks.Controller
             if (_listener != null)
             {
                 _listener.Stop();
+            }
+
+            if (_availabilityStatics == null)
+            {
+                _availabilityStatics = new AvailabilityStatistics();
+                _availabilityStatics.UpdateConfiguration(_config);
             }
 
             // don't put polipoRunner.Start() before pacServer.Stop()

--- a/shadowsocks-csharp/Controller/Strategy/SimplyChooseByStatisticsStrategy.cs
+++ b/shadowsocks-csharp/Controller/Strategy/SimplyChooseByStatisticsStrategy.cs
@@ -125,7 +125,7 @@ namespace Shadowsocks.Controller.Strategy
 
         string IStrategy.Name
         {
-            get { return I18N.GetString("Simply Choose By Statics"); }
+            get { return I18N.GetString("Choose By Total Package Loss"); }
         }
 
         Server IStrategy.GetAServer(IStrategyCallerType type, IPEndPoint localIPEndPoint)

--- a/shadowsocks-csharp/Controller/Strategy/SimplyChooseByStatisticsStrategy.cs
+++ b/shadowsocks-csharp/Controller/Strategy/SimplyChooseByStatisticsStrategy.cs
@@ -106,7 +106,6 @@ namespace Shadowsocks.Controller.Strategy
                                   ).Aggregate((result1, result2) => result1.score > result2.score ? result1 : result2);
 
                 Logging.Debug(string.Format("best server {0}: {1}", bestResult.server.FriendlyName(), bestResult.score));
-                Console.WriteLine("Switch to server by statistics: {0}", bestResult.server.FriendlyName());
                 _currentServer = bestResult.server;
             }
             catch (Exception e)
@@ -127,6 +126,7 @@ namespace Shadowsocks.Controller.Strategy
 
         Server IStrategy.GetAServer(IStrategyCallerType type, IPEndPoint localIPEndPoint)
         {
+            Console.WriteLine("Switch to server by statistics: {0}", _currentServer.FriendlyName());
             return _currentServer;  //current server cached for CachedInterval
         }
 

--- a/shadowsocks-csharp/Controller/Strategy/SimplyChooseByStatisticsStrategy.cs
+++ b/shadowsocks-csharp/Controller/Strategy/SimplyChooseByStatisticsStrategy.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Shadowsocks.Model;
+using System.IO;
+using System.Net.NetworkInformation;
+using System.Threading;
+
+namespace Shadowsocks.Controller.Strategy
+{
+    class SimplyChooseByStatisticsStrategy : IStrategy
+    {
+        private ShadowsocksController _controller;
+        private Server _currentServer;
+        private Timer timer;
+        private Dictionary<string, StatisticsData> statistics;
+        private static readonly int CachedInterval = 60 * 60 * 1000; //choose a new server every 60 minutes
+
+        public SimplyChooseByStatisticsStrategy(ShadowsocksController controller)
+        {
+            _controller = controller;
+            _currentServer = null;  //we can also choose a server randomly at first
+            timer = new Timer(ReloadStatisticsAndChooseAServer);
+        }
+
+        private void ReloadStatisticsAndChooseAServer(object obj)
+        {
+            Logging.Debug("Reloading statistics and choose a new server....");
+            List<Server> servers = _controller.GetCurrentConfiguration().configs;
+            LoadStatistics();
+            ChooseNewServer(servers);
+        }
+
+        /*
+        return a dict:
+        {
+            'ServerFriendlyName1':StatisticsData,
+            'ServerFriendlyName2':...
+        }
+        */
+        private void LoadStatistics()
+        {
+            try
+            {
+                var path = AvailabilityStatistics.AvailabilityStatisticsFile;
+                Logging.Debug(string.Format("loading statistics from{0}", path));
+                statistics = (from l in File.ReadAllLines(path)
+                                  .Skip(1)
+                                  let strings = l.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
+                                  let rawData = new
+                                  {
+                                      ServerName = strings[1],
+                                      IPStatus = strings[2],
+                                      RoundtripTime = int.Parse(strings[3])
+                                  }
+                                  group rawData by rawData.ServerName into server
+                                  select new
+                                  {
+                                      ServerName = server.Key,
+                                      data = new StatisticsData
+                                      {
+                                          SuccessTimes = server.Count(data => IPStatus.Success.ToString().Equals(data.IPStatus)),
+                                          TimedOutTimes = server.Count(data => IPStatus.TimedOut.ToString().Equals(data.IPStatus)),
+                                          AverageResponse = Convert.ToInt32(server.Average(data => data.RoundtripTime)),
+                                          MinResponse = server.Min(data => data.RoundtripTime),
+                                          MaxResponse = server.Max(data => data.RoundtripTime)
+                                      }
+                                  }).ToDictionary(server => server.ServerName, server => server.data);
+            }
+            catch (Exception e)
+            {
+                Logging.LogUsefulException(e);
+            }
+        }
+
+        //return the score by data
+        //server with highest score will be choosen
+        private static double GetScore(StatisticsData data)
+        {
+            return (double)data.SuccessTimes / (data.SuccessTimes + data.TimedOutTimes); //simply choose min package loss
+        }
+
+        private class StatisticsData
+        {
+            public int SuccessTimes;
+            public int TimedOutTimes;
+            public int AverageResponse;
+            public int MinResponse;
+            public int MaxResponse;
+        }
+
+        private void ChooseNewServer(List<Server> servers)
+        {
+            try
+            {
+                var bestResult = (from server in servers
+                                  let name = server.FriendlyName()
+                                  where statistics.ContainsKey(name)
+                                  select new
+                                  {
+                                      server,
+                                      score = GetScore(statistics[name])
+                                  }
+                                  ).Aggregate((result1, result2) => result1.score > result2.score ? result1 : result2);
+
+                Logging.Debug(string.Format("best server {0}: {1}", bestResult.server.FriendlyName(), bestResult.score));
+                Console.WriteLine("Switch to server by statistics: {0}", bestResult.server.FriendlyName());
+                _currentServer = bestResult.server;
+            }
+            catch (Exception e)
+            {
+                Logging.LogUsefulException(e);
+            }
+        }
+
+        string IStrategy.ID
+        {
+            get { return "com.shadowsocks.strategy.scbs"; }
+        }
+
+        string IStrategy.Name
+        {
+            get { return I18N.GetString("Simply Choose By Statics"); }
+        }
+
+        Server IStrategy.GetAServer(IStrategyCallerType type, IPEndPoint localIPEndPoint)
+        {
+            return _currentServer;  //current server cached for CachedInterval
+        }
+
+        void IStrategy.ReloadServers()
+        {
+            ChooseNewServer(_controller.GetCurrentConfiguration().configs);
+            timer?.Change(0, CachedInterval);
+        }
+
+        void IStrategy.SetFailure(Server server)
+        {
+            Logging.Debug(String.Format("failure: {0}", server.FriendlyName()));
+        }
+
+        void IStrategy.UpdateLastRead(Server server)
+        {
+            //TODO: combine this part of data with ICMP statics
+        }
+
+        void IStrategy.UpdateLastWrite(Server server)
+        {
+            //TODO: combine this part of data with ICMP statics
+        }
+
+        void IStrategy.UpdateLatency(Server server, TimeSpan latency)
+        {
+            //TODO: combine this part of data with ICMP statics
+        }
+
+    }
+}

--- a/shadowsocks-csharp/Controller/Strategy/SimplyChooseByStatisticsStrategy.cs
+++ b/shadowsocks-csharp/Controller/Strategy/SimplyChooseByStatisticsStrategy.cs
@@ -93,6 +93,10 @@ namespace Shadowsocks.Controller.Strategy
 
         private void ChooseNewServer(List<Server> servers)
         {
+            if (statistics == null)
+            {
+                return;
+            }
             try
             {
                 var bestResult = (from server in servers

--- a/shadowsocks-csharp/Controller/Strategy/StrategyManager.cs
+++ b/shadowsocks-csharp/Controller/Strategy/StrategyManager.cs
@@ -13,6 +13,7 @@ namespace Shadowsocks.Controller.Strategy
             _strategies = new List<IStrategy>();
             _strategies.Add(new BalancingStrategy(controller));
             _strategies.Add(new HighAvailabilityStrategy(controller));
+            _strategies.Add(new SimplyChooseByStatisticsStrategy(controller));
             // TODO: load DLL plugins
         }
         public IList<IStrategy> GetStrategies()

--- a/shadowsocks-csharp/Data/cn.txt
+++ b/shadowsocks-csharp/Data/cn.txt
@@ -25,7 +25,7 @@ Quit=退出
 Edit Servers=编辑服务器
 Load Balance=负载均衡
 High Availability=高可用
-Simply Choose By Statistics=根据统计
+Choose By Total Package Loss=累计丢包率
 
 # Config Form
 

--- a/shadowsocks-csharp/Data/cn.txt
+++ b/shadowsocks-csharp/Data/cn.txt
@@ -25,6 +25,7 @@ Quit=退出
 Edit Servers=编辑服务器
 Load Balance=负载均衡
 High Availability=高可用
+Simply Choose By Statistics=根据统计
 
 # Config Form
 

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -22,6 +22,7 @@ namespace Shadowsocks.Model
         public int localPort;
         public string pacUrl;
         public bool useOnlinePac;
+        public bool availabilityStatistics;
 
         private static string CONFIG_FILE = "gui-config.json";
 

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -29,6 +29,7 @@ namespace Shadowsocks.View
         private MenuItem enableItem;
         private MenuItem modeItem;
         private MenuItem AutoStartupItem;
+        private MenuItem AvailabilityStatistics;
         private MenuItem ShareOverLANItem;
         private MenuItem SeperatorItem;
         private MenuItem ConfigItem;
@@ -177,6 +178,7 @@ namespace Shadowsocks.View
                 }),
                 new MenuItem("-"),
                 this.AutoStartupItem = CreateMenuItem("Start on Boot", new EventHandler(this.AutoStartupItem_Click)),
+                this.AvailabilityStatistics = CreateMenuItem("Availability Statistics", new EventHandler(this.AvailabilityStatisticsItem_Click)),
                 this.ShareOverLANItem = CreateMenuItem("Allow Clients from LAN", new EventHandler(this.ShareOverLANItem_Click)),
                 new MenuItem("-"),
                 CreateMenuItem("Show Logs...", new EventHandler(this.ShowLogItem_Click)),
@@ -260,6 +262,7 @@ namespace Shadowsocks.View
             PACModeItem.Checked = !config.global;
             ShareOverLANItem.Checked = config.shareOverLan;
             AutoStartupItem.Checked = AutoStartup.Check();
+            AvailabilityStatistics.Checked = config.availabilityStatistics;
             onlinePACItem.Checked = onlinePACItem.Enabled && config.useOnlinePac;
             localPACItem.Checked = !onlinePACItem.Checked;
             UpdatePACItemsEnabledStatus();
@@ -522,6 +525,11 @@ namespace Shadowsocks.View
 			if (!AutoStartup.Set(AutoStartupItem.Checked)) {
 				MessageBox.Show(I18N.GetString("Failed to update registry"));
 			}
+		}
+
+		private void AvailabilityStatisticsItem_Click(object sender, EventArgs e) {
+			AvailabilityStatistics.Checked = !AvailabilityStatistics.Checked;
+            controller.ToggleAvailabilityStatistics(AvailabilityStatistics.Checked);
 		}
 
         private void LocalPACItem_Click(object sender, EventArgs e)

--- a/shadowsocks-csharp/shadowsocks-csharp.csproj
+++ b/shadowsocks-csharp/shadowsocks-csharp.csproj
@@ -123,7 +123,9 @@
     <Compile Include="3rd\zxing\ResultPoint.cs" />
     <Compile Include="3rd\zxing\ResultPointCallback.cs" />
     <Compile Include="3rd\zxing\WriterException.cs" />
+    <Compile Include="Controller\Service\AvailabilityStatistics.cs" />
     <Compile Include="Controller\Strategy\HighAvailabilityStrategy.cs" />
+    <Compile Include="Controller\Strategy\SimplyChooseByStatisticsStrategy.cs" />
     <Compile Include="Controller\System\AutoStartup.cs" />
     <Compile Include="Controller\FileManager.cs" />
     <Compile Include="Controller\Service\GFWListUpdater.cs" />


### PR DESCRIPTION
Strategy: Simply Choose By Statistics

<img src="https://cloud.githubusercontent.com/assets/2814357/9180910/6a475d94-3fd6-11e5-8b80-4fb762d38b3a.png" /img>

启用该选项后后台定时（目前是60分钟，似乎应该调小一些）利用 .Net [原生接口](https://msdn.microsoft.com/en-us/library/System.Net.NetworkInformation(v=vs.110).aspx)收集到所有代理的ICMP数据，然后记录在文件里。（可能的改进是对于 Strategy 默认提供的 LastRead，LastWrite 等事件也记录下来）
可以用于统计分析，比如基于时间段，在晚间（中美线路高峰），代理1的表现可能比代理2更好，白天则代理2更好。等等。
Strategy 可以读取文件自行设计算法，我已经写了一个简单的（选择历史总丢包率最小的）。除了ReloadServers事件以外，每隔60分钟根据数据计算一次然后选择。
<img width="359" alt="2015-08-11_03-20-25" src="https://cloud.githubusercontent.com/assets/2814357/9181503/f1aaa7c2-3fd7-11e5-8d1b-17708bd11b6b.png">

