### PR TITLE
Fix a tiny bug

### DIFF
--- a/shadowsocks-csharp/View/ConfigForm.cs
+++ b/shadowsocks-csharp/View/ConfigForm.cs
@@ -146,6 +146,28 @@ namespace Shadowsocks.View
 
         }
 
+        private void ConfigForm_KeyDown(object sender, KeyEventArgs e)
+        {
+            // Sometimes the users may hit enter key by mistake, and the form will close without saving entries.
+
+            if (e.KeyCode == Keys.Enter)
+            {
+                Server server = controller.GetCurrentServer();
+                if (!SaveOldSelectedServer())
+                {
+                    return;
+                }
+                if (_modifiedConfiguration.configs.Count == 0)
+                {
+                    MessageBox.Show(I18N.GetString("Please add at least one server"));
+                    return;
+                }
+                controller.SaveServers(_modifiedConfiguration.configs, _modifiedConfiguration.localPort);
+                controller.SelectServerIndex(_modifiedConfiguration.configs.IndexOf(server));
+            }
+
+        }
+
         private void ServersListBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (!ServersListBox.CanSelect)


### PR DESCRIPTION
Sometimes the users may hit enter key by mistake, and the form will
close without saving entries.
有时在设置代理时，若不慎按下回车，窗口会关闭而且设置内容不会保存。
该commit修复了这个问题，当回车键按下后，会保存设置。