### PR TITLE
no repeat random number generator by GangZhuo

### DIFF
--- a/shadowsocks-csharp/Encryption/IVEncryptor.cs
+++ b/shadowsocks-csharp/Encryption/IVEncryptor.cs
@@ -88,7 +88,8 @@ namespace Shadowsocks.Encryption
         protected static void randBytes(byte[] buf, int length)
         {
             byte[] temp = new byte[length];
-            new Random().NextBytes(temp);
+            RNGCryptoServiceProvider rngServiceProvider = new RNGCryptoServiceProvider();
+            rngServiceProvider.GetBytes(temp);
             temp.CopyTo(buf, 0);
         }
 


### PR DESCRIPTION
Part of pull request #313 

>The stock code use class Random to generate IV, the Random is pseudo random number generator. The IV maybe repeat, this will cause shadowsocks-libev closed the sockets with the error message 'invalid password or cipher'. Reference https://github.com/shadowsocks/shadowsocks-libev/issues/389

>Solution is use class RNGCryptoServiceProvider to generate IV, of course it's lower performance, but a little bit.