### PR TITLE
Test connection speed

### DIFF
--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -252,7 +252,9 @@ namespace Shadowsocks.Controller
 
         public static string GetQRCode(Server server)
         {
-            string parts = server.method + ":" + server.password + "@" + server.server + ":" + server.server_port;
+            string parts = server.method;
+            if (server.auth) parts += "-auth";
+            parts += ":" + server.password + "@" + server.server + ":" + server.server_port;
             string base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(parts));
             return "ss://" + base64;
         }


### PR DESCRIPTION
This PR is meant to show off a feature that basically works for me. :laughing:

What it does: for every config, switch to it, download a 1.53MB files in 4s or time out. Save the results to its `remark` and pick the fastest one.

Bugs/problems:
* No localization;
* It can create a huge number of threads if there are a lot of configs that doesn't work at all; (using `Thread.Abort` isn't a good practice, and it doesn't do much because most of the time the thread is stuck running unmanaged code)  
  This may lead to `OutOfMemoryException`. A possible resolution is to use `TaskFactory` to manage the threads and wait for them to finish when there are a large number of threads.
* No customization;  
  I only picked the config that works best for me.
* I use system console for output which is ugly, use a better UI;
* Terminating have some bug;
* No unit tests;
* Maybe more.
