### PR TITLE
Disable StatisticsStrategy by default.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+3.1 2016-05-01
+- Disable StatisticsStrategy by default
+
 3.0 2016-03-02
 - Update Privoxy to 3.0.24
 - Replace Choose by Total Packet Loss with Choose by Statistics

--- a/shadowsocks-csharp/Controller/Service/UpdateChecker.cs
+++ b/shadowsocks-csharp/Controller/Service/UpdateChecker.cs
@@ -23,7 +23,7 @@ namespace Shadowsocks.Controller
         public string LatestVersionLocalName;
         public event EventHandler CheckUpdateCompleted;
 
-        public const string Version = "3.0";
+        public const string Version = "3.1";
 
         private class CheckUpdateTimer : System.Timers.Timer
         {

--- a/shadowsocks-csharp/Model/StatisticsStrategyConfiguration.cs
+++ b/shadowsocks-csharp/Model/StatisticsStrategyConfiguration.cs
@@ -14,7 +14,7 @@ namespace Shadowsocks.Model
     public class StatisticsStrategyConfiguration
     {
         public static readonly string ID = "com.shadowsocks.strategy.statistics";
-        public bool StatisticsEnabled { get; set; } = true;
+        public bool StatisticsEnabled { get; set; } = false;
         public bool ByHourOfDay { get; set; } = true;
         public bool Ping { get; set; }
         public int ChoiceKeptMinutes { get; set; } = 10;

--- a/shadowsocks-csharp/Properties/AssemblyInfo.cs
+++ b/shadowsocks-csharp/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Shadowsocks")]
-[assembly: AssemblyCopyright("Copyright © clowwindy 2015")]
+[assembly: AssemblyCopyright("clowwindy and community 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
As the StatisticsStrategy is not stable, it should be disable by default.