### PR TITLE
fixed bandwidth counting by servers

### DIFF
--- a/shadowsocks-csharp/Controller/Service/Listener.cs
+++ b/shadowsocks-csharp/Controller/Service/Listener.cs
@@ -78,7 +78,7 @@ namespace Shadowsocks.Controller
                 _tcpSocket.Listen(1024);
 
                 // Start an asynchronous socket to listen for connections.
-                Logging.Info("Shadowsocks started");
+                Logging.Info($"Shadowsocks started, using [{_config.GetCurrentServer().FriendlyName()}].");
                 _tcpSocket.BeginAccept(new AsyncCallback(AcceptCallback), _tcpSocket);
                 UDPState udpState = new UDPState();
                 _udpSocket.BeginReceiveFrom(udpState.buffer, 0, udpState.buffer.Length, 0, ref udpState.remoteEndPoint, new AsyncCallback(RecvFromCallback), udpState);

--- a/shadowsocks-csharp/Controller/Service/TCPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/TCPRelay.cs
@@ -69,14 +69,14 @@ namespace Shadowsocks.Controller
             return true;
         }
 
-        public void UpdateInboundCounter(Server server, long n)
+        public void IncreaseInboundCounter(Server server, long n)
         {
-            _controller.UpdateInboundCounter(server, n);
+            _controller.IncreaseInboundCounter(server, n);
         }
 
-        public void UpdateOutboundCounter(Server server, long n)
+        public void IncreaseOutboundCounter(Server server, long n)
         {
-            _controller.UpdateOutboundCounter(server, n);
+            _controller.IncreaseOutboundCounter(server, n);
         }
 
         public void UpdateLatency(Server server, TimeSpan latency)
@@ -540,7 +540,7 @@ namespace Shadowsocks.Controller
             {
                 int bytesRead = remote.EndReceive(ar);
                 totalRead += bytesRead;
-                tcprelay.UpdateInboundCounter(server, bytesRead);
+                tcprelay.IncreaseInboundCounter(server, bytesRead);
 
                 if (bytesRead > 0)
                 {
@@ -607,7 +607,7 @@ namespace Shadowsocks.Controller
                         encryptor.Encrypt(connetionRecvBuffer, bytesRead, connetionSendBuffer, out bytesToSend);
                     }
                     Logging.Debug(remote, bytesToSend, "TCP Relay", "@PipeConnectionReceiveCallback() (upload)");
-                    tcprelay.UpdateOutboundCounter(server, bytesToSend);
+                    tcprelay.IncreaseOutboundCounter(server, bytesToSend);
                     _startSendingTime = DateTime.Now;
                     _bytesToSend = bytesToSend;
                     remote.BeginSend(connetionSendBuffer, 0, bytesToSend, 0, new AsyncCallback(PipeRemoteSendCallback), null);

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -33,8 +33,8 @@ namespace Shadowsocks.Controller
         public AvailabilityStatistics availabilityStatistics = AvailabilityStatistics.Instance;
         public StatisticsStrategyConfiguration StatisticsConfiguration { get; private set; }
 
-        public long inboundCounter = 0;
-        public long outboundCounter = 0;
+        public long InboundCounter { get { return _config.GetCurrentServer().bandwidthIn; } }
+        public long OutboundCounter { get { return _config.GetCurrentServer().bandwidthOut; } }
 
         private bool stopped = false;
 
@@ -317,18 +317,20 @@ namespace Shadowsocks.Controller
             }
         }
 
-        public void UpdateInboundCounter(Server server, long n)
+        public void IncreaseInboundCounter(Server server, long n)
         {
-            Interlocked.Add(ref inboundCounter, n);
+            Interlocked.Add(ref server.bandwidthIn, n);
+
             if (_config.availabilityStatistics)
             {
                 new Task(() => availabilityStatistics.UpdateInboundCounter(server, n)).Start();
             }
         }
 
-        public void UpdateOutboundCounter(Server server, long n)
+        public void IncreaseOutboundCounter(Server server, long n)
         {
-            Interlocked.Add(ref outboundCounter, n);
+            Interlocked.Add(ref server.bandwidthOut, n);
+
             if (_config.availabilityStatistics)
             {
                 new Task(() => availabilityStatistics.UpdateOutboundCounter(server, n)).Start();
@@ -457,6 +459,7 @@ namespace Shadowsocks.Controller
         }
 
         private static readonly IEnumerable<char> IgnoredLineBegins = new[] { '!', '[' };
+
         private void pacServer_UserRuleFileChanged(object sender, EventArgs e)
         {
             // TODO: this is a dirty hack. (from code GListUpdater.http_DownloadStringCompleted())

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -224,6 +224,7 @@ namespace Shadowsocks.Controller
             {
                 SystemProxy.Update(_config, true);
             }
+            SaveConfig(_config);
         }
 
         public void TouchPACFile()

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -207,6 +207,7 @@ namespace Shadowsocks.Controller
 
         public void Stop()
         {
+            SaveConfig(_config);
             if (stopped)
             {
                 return;
@@ -224,7 +225,6 @@ namespace Shadowsocks.Controller
             {
                 SystemProxy.Update(_config, true);
             }
-            SaveConfig(_config);
         }
 
         public void TouchPACFile()

--- a/shadowsocks-csharp/Data/cn.txt
+++ b/shadowsocks-csharp/Data/cn.txt
@@ -61,7 +61,7 @@ Change &Font=设置字体(&F)
 &Wrap Text=自动换行(&W)
 &Top Most=置顶(&T)
 &Show Toolbar=显示工具栏(&S)
-Log Viewer=日志查看器
+Log [DL:{0}, UL:{1}]=日志 [下载:{0}, 上传:{1}]
 
 # QRCode Form
 

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -83,6 +83,7 @@ namespace Shadowsocks.Model
             if (config.index == -1 && config.strategy == null)
                 config.index = 0;
             config.isDefault = false;
+
             try
             {
                 using (StreamWriter sw = new StreamWriter(File.Open(CONFIG_FILE, FileMode.Create)))

--- a/shadowsocks-csharp/Model/Server.cs
+++ b/shadowsocks-csharp/Model/Server.cs
@@ -21,6 +21,8 @@ namespace Shadowsocks.Model
         public string method;
         public string remarks;
         public bool auth;
+        public long bandwidthIn;
+        public long bandwidthOut;
 
         public override int GetHashCode()
         {
@@ -57,6 +59,8 @@ namespace Shadowsocks.Model
             password = "";
             remarks = "";
             auth = false;
+            bandwidthIn = 0;
+            bandwidthOut = 0;
         }
 
         public Server(string ssURL) : this()

--- a/shadowsocks-csharp/View/ConfigForm.Designer.cs
+++ b/shadowsocks-csharp/View/ConfigForm.Designer.cs
@@ -471,7 +471,6 @@
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Edit Servers";
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.ConfigForm_FormClosed);
-            this.Load += new System.EventHandler(this.ConfigForm_Load);
             this.Shown += new System.EventHandler(this.ConfigForm_Shown);
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();

--- a/shadowsocks-csharp/View/ConfigForm.cs
+++ b/shadowsocks-csharp/View/ConfigForm.cs
@@ -144,11 +144,6 @@ namespace Shadowsocks.View
             LoadSelectedServer();
         }
 
-        private void ConfigForm_Load(object sender, EventArgs e)
-        {
-
-        }
-
         private void ConfigForm_KeyDown(object sender, KeyEventArgs e)
         {
             // Sometimes the users may hit enter key by mistake, and the form will close without saving entries.

--- a/shadowsocks-csharp/View/ConfigForm.cs
+++ b/shadowsocks-csharp/View/ConfigForm.cs
@@ -84,7 +84,9 @@ namespace Shadowsocks.View
                     password = PasswordTextBox.Text,
                     method = EncryptionSelect.Text,
                     remarks = RemarksTextBox.Text,
-                    auth = OneTimeAuth.Checked
+                    auth = OneTimeAuth.Checked,
+                    bandwidthIn = controller.GetCurrentServer().bandwidthIn,
+                    bandwidthOut = controller.GetCurrentServer().bandwidthOut
                 };
                 int localPort = int.Parse(ProxyPortTextBox.Text);
                 Configuration.CheckServer(server);

--- a/shadowsocks-csharp/View/LogForm.cs
+++ b/shadowsocks-csharp/View/LogForm.cs
@@ -109,8 +109,9 @@ namespace Shadowsocks.View
                 lastOffset = reader.BaseStream.Position;
             }
 
-            this.Text = I18N.GetString("Log Viewer") +
-                $" [in: {Utils.FormatBandwidth(controller.inboundCounter)}, out: {Utils.FormatBandwidth(controller.outboundCounter)}]";
+            this.Text = String.Format(I18N.GetString("Log [DL:{0}, UL:{1}]"),
+                                      Utils.FormatBandwidth(controller.InboundCounter),
+                                      Utils.FormatBandwidth(controller.OutboundCounter));
         }
 
         private void LogForm_Load(object sender, EventArgs e)


### PR DESCRIPTION
The bandwidth counting previously I PRed has bug that it can't record bandwidth by each server. Now it's fixed.

The bandwidth is record in config file like follows,
```
{
  "configs": [
    {
      "server": "1.2.3.4",
      "remarks": "My SS Server #1",
      ...
      "bandwidthIn": 46336870,
      "bandwidthOut": 904840
    },
    {
      "server": "a.b.c.d",
...
```