### PR TITLE
New Feature: print "connect to hostname:port" to log

### DIFF
--- a/shadowsocks-csharp/Util/Util.cs
+++ b/shadowsocks-csharp/Util/Util.cs
@@ -76,7 +76,8 @@ namespace Shadowsocks.Util
                 //
                 // just kidding
                 SetProcessWorkingSetSize(Process.GetCurrentProcess().Handle,
-                    (UIntPtr)0xFFFFFFFF, (UIntPtr)0xFFFFFFFF);
+                                         (UIntPtr)0xFFFFFFFF,
+                                         (UIntPtr)0xFFFFFFFF);
             }
         }
 
@@ -87,7 +88,8 @@ namespace Shadowsocks.Util
             using (MemoryStream sb = new MemoryStream())
             {
                 using (GZipStream input = new GZipStream(new MemoryStream(buf),
-                    CompressionMode.Decompress, false))
+                                                         CompressionMode.Decompress,
+                                                         false))
                 {
                     while ((n = input.Read(buffer, 0, buffer.Length)) > 0)
                     {


### PR DESCRIPTION
- featured print "connect to hostname:port" to log
- renamed private properties with prefix underline
- clean up code in C# 6
- clean up buggy parameter.
  - Replaced SocketFlags.None (an enum which euqals 0) from zero.