### PR TITLE
日志相关修改

### DIFF
--- a/shadowsocks-csharp/Controller/Logging.cs
+++ b/shadowsocks-csharp/Controller/Logging.cs
@@ -12,14 +12,17 @@ namespace Shadowsocks.Controller
     {
         public static string LogFilePath;
 
+        private static FileStream fs;
+        private static StreamWriterWithTimestamp sw;
+
         public static bool OpenLogFile()
         {
             try
             {
                 LogFilePath = Utils.GetTempPath("shadowsocks.log");
 
-                FileStream fs = new FileStream(LogFilePath, FileMode.Append);
-                StreamWriterWithTimestamp sw = new StreamWriterWithTimestamp(fs);
+                fs = new FileStream(LogFilePath, FileMode.Append);
+                sw = new StreamWriterWithTimestamp(fs);
                 sw.AutoFlush = true;
                 Console.SetOut(sw);
                 Console.SetError(sw);
@@ -35,7 +38,10 @@ namespace Shadowsocks.Controller
 
         private static void WriteToLogFile(object o)
         {
-            Console.WriteLine(o);
+            try {
+                Console.WriteLine(o);
+            } catch(ObjectDisposedException) {
+            }
         }
 
         public static void Error(object o)
@@ -46,6 +52,15 @@ namespace Shadowsocks.Controller
         public static void Info(object o)
         {
             WriteToLogFile(o);
+        }
+
+        public static void clear() {
+            sw.Close();
+            sw.Dispose();
+            fs.Close();
+            fs.Dispose();
+            File.Delete(LogFilePath);
+            OpenLogFile();
         }
 
         [Conditional("DEBUG")]

--- a/shadowsocks-csharp/Model/LogViewerConfig.cs
+++ b/shadowsocks-csharp/Model/LogViewerConfig.cs
@@ -19,6 +19,7 @@ namespace Shadowsocks.Model
         public int height;
         public int top;
         public int left;
+        public bool maximized;
 
         public LogViewerConfig()
         {
@@ -33,6 +34,7 @@ namespace Shadowsocks.Model
             height = 400;
             left = GetBestLeft();
             top = GetBestTop();
+            maximized = true;
         }
 
         // Use GetBestTop() and GetBestLeft() to ensure the log viwer form can be always display IN screen. 

--- a/shadowsocks-csharp/View/LogForm.cs
+++ b/shadowsocks-csharp/View/LogForm.cs
@@ -190,6 +190,9 @@ namespace Shadowsocks.View
             Width = config.width;
             Top = config.GetBestTop();
             Left = config.GetBestLeft();
+            if(config.maximized) {
+                WindowState = FormWindowState.Maximized;
+            }
 
             topMostTriggerLock = true;
             TopMost = TopMostMenuItem.Checked = TopMostCheckBox.Checked = topMostTrigger;
@@ -215,10 +218,12 @@ namespace Shadowsocks.View
             config.SetFont(LogMessageTextBox.Font);
             config.SetBackgroundColor(LogMessageTextBox.BackColor);
             config.SetTextColor(LogMessageTextBox.ForeColor);
-            config.top = Top;
-            config.left = Left;
-            config.height = Height;
-            config.width = Width;
+            if(!(config.maximized = WindowState == FormWindowState.Maximized)) {
+                config.top = Top;
+                config.left = Left;
+                config.height = Height;
+                config.width = Width;
+            }
             controller.SaveLogViewerConfig(config);
         }
 

--- a/shadowsocks-csharp/View/LogForm.cs
+++ b/shadowsocks-csharp/View/LogForm.cs
@@ -149,25 +149,25 @@ namespace Shadowsocks.View
 
         private void UpdateContent()
         {
-            using (StreamReader reader = new StreamReader(new FileStream(filename,
-                     FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
-            {
-                reader.BaseStream.Seek(lastOffset, SeekOrigin.Begin);
+            try {
+                using(StreamReader reader = new StreamReader(new FileStream(filename,
+                         FileMode.Open, FileAccess.Read, FileShare.ReadWrite))) {
+                    reader.BaseStream.Seek(lastOffset, SeekOrigin.Begin);
 
-                string line = "";
-                bool changed = false;
-                while ((line = reader.ReadLine()) != null)
-                {
-                    changed = true;
-                    LogMessageTextBox.AppendText(line + Environment.NewLine);
+                    string line = "";
+                    bool changed = false;
+                    while((line = reader.ReadLine()) != null) {
+                        changed = true;
+                        LogMessageTextBox.AppendText(line + Environment.NewLine);
+                    }
+
+                    if(changed) {
+                        LogMessageTextBox.ScrollToCaret();
+                    }
+
+                    lastOffset = reader.BaseStream.Position;
                 }
-
-                if (changed)
-                {
-                    LogMessageTextBox.ScrollToCaret();
-                }
-
-                lastOffset = reader.BaseStream.Position;
+            } catch(FileNotFoundException) {
             }
 
             this.Text = I18N.GetString("Log Viewer") +
@@ -247,6 +247,8 @@ namespace Shadowsocks.View
         #region Clean up the content in LogMessageTextBox.
         private void DoCleanLogs()
         {
+            Logging.clear();
+            lastOffset = 0;
             LogMessageTextBox.Clear();
         }
 


### PR DESCRIPTION
## 日志窗口支持最大化
之前的日志窗口不能最大化，窗口最大显示的时候，总是显示在左上角超出屏幕的位置，看着总是很别扭。

## 日志里的清空日志直接清空日志文件
之前的清空日志仅仅是删除下面显示的内容，没什么用。而日志文件一直在temp文件夹下，一段时间以来体积已经增长至十几M了，历史久远的日志没有必要保留，所以我改成了直接清空日志文件。