### PR TITLE
New approach to record and calculate inbound/outbound speed.

### DIFF
--- a/shadowsocks-csharp/Controller/Service/Listener.cs
+++ b/shadowsocks-csharp/Controller/Service/Listener.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -10,9 +11,18 @@ namespace Shadowsocks.Controller
 {
     public class Listener
     {
-        public interface Service
+        public interface IService
         {
             bool Handle(byte[] firstPacket, int length, Socket socket, object state);
+
+            void Stop();
+        }
+
+        public abstract class Service : IService
+        {
+            public abstract bool Handle(byte[] firstPacket, int length, Socket socket, object state);
+
+            public virtual void Stop() { }
         }
 
         public class UDPState
@@ -25,9 +35,9 @@ namespace Shadowsocks.Controller
         bool _shareOverLAN;
         Socket _tcpSocket;
         Socket _udpSocket;
-        IList<Service> _services;
+        List<IService> _services;
 
-        public Listener(IList<Service> services)
+        public Listener(List<IService> services)
         {
             this._services = services;
         }
@@ -97,6 +107,8 @@ namespace Shadowsocks.Controller
                 _udpSocket.Close();
                 _udpSocket = null;
             }
+
+            _services.ForEach(s=>s.Stop());
         }
 
         public void RecvFromCallback(IAsyncResult ar)
@@ -105,7 +117,7 @@ namespace Shadowsocks.Controller
             try
             {
                 int bytesRead = _udpSocket.EndReceiveFrom(ar, ref state.remoteEndPoint);
-                foreach (Service service in _services)
+                foreach (IService service in _services)
                 {
                     if (service.Handle(state.buffer, bytesRead, _udpSocket, state))
                     {
@@ -187,7 +199,7 @@ namespace Shadowsocks.Controller
             try
             {
                 int bytesRead = conn.EndReceive(ar);
-                foreach (Service service in _services)
+                foreach (IService service in _services)
                 {
                     if (service.Handle(buf, bytesRead, conn, null))
                     {

--- a/shadowsocks-csharp/Controller/Service/PACServer.cs
+++ b/shadowsocks-csharp/Controller/Service/PACServer.cs
@@ -35,7 +35,7 @@ namespace Shadowsocks.Controller
             this._config = config;
         }
 
-        public bool Handle(byte[] firstPacket, int length, Socket socket, object state)
+        public override bool Handle(byte[] firstPacket, int length, Socket socket, object state)
         {
             if (socket.ProtocolType != ProtocolType.Tcp)
             {

--- a/shadowsocks-csharp/Controller/Service/PortForwarder.cs
+++ b/shadowsocks-csharp/Controller/Service/PortForwarder.cs
@@ -14,7 +14,7 @@ namespace Shadowsocks.Controller
             this._targetPort = targetPort;
         }
 
-        public bool Handle(byte[] firstPacket, int length, Socket socket, object state)
+        public override bool Handle(byte[] firstPacket, int length, Socket socket, object state)
         {
             if (socket.ProtocolType != ProtocolType.Tcp)
             {

--- a/shadowsocks-csharp/Controller/Service/TCPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/TCPRelay.cs
@@ -29,7 +29,7 @@ namespace Shadowsocks.Controller
             _lastSweepTime = DateTime.Now;
         }
 
-        public bool Handle(byte[] firstPacket, int length, Socket socket, object state)
+        public override bool Handle(byte[] firstPacket, int length, Socket socket, object state)
         {
             if (socket.ProtocolType != ProtocolType.Tcp
                 || (length < 2 || firstPacket[0] != 5))
@@ -60,6 +60,16 @@ namespace Shadowsocks.Controller
                 handler1.Close();
             }
             return true;
+        }
+
+        public override void Stop()
+        {
+            List<TCPHandler> handlersToClose = new List<TCPHandler>();
+            lock (Handlers)
+            {
+                handlersToClose.AddRange(Handlers);
+            }
+            handlersToClose.ForEach(h=>h.Close());
         }
 
         public void UpdateInboundCounter(Server server, long n)

--- a/shadowsocks-csharp/Controller/Service/UDPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/UDPRelay.cs
@@ -24,7 +24,7 @@ namespace Shadowsocks.Controller
             this._cache = new LRUCache<IPEndPoint, UDPHandler>(512);  // todo: choose a smart number
         }
 
-        public bool Handle(byte[] firstPacket, int length, Socket socket, object state)
+        public override bool Handle(byte[] firstPacket, int length, Socket socket, object state)
         {
             if (socket.ProtocolType != ProtocolType.Udp)
             {

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -429,7 +429,7 @@ namespace Shadowsocks.Controller
 
                 TCPRelay tcpRelay = new TCPRelay(this, _config);
                 UDPRelay udpRelay = new UDPRelay(this);
-                List<Listener.Service> services = new List<Listener.Service>();
+                List<Listener.IService> services = new List<Listener.IService>();
                 services.Add(tcpRelay);
                 services.Add(udpRelay);
                 services.Add(_pacServer);

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -33,8 +33,10 @@ namespace Shadowsocks.Controller
         public AvailabilityStatistics availabilityStatistics = AvailabilityStatistics.Instance;
         public StatisticsStrategyConfiguration StatisticsConfiguration { get; private set; }
 
-        public long inboundCounter = 0;
-        public long outboundCounter = 0;
+        private long _inboundCounter = 0;
+        private long _outboundCounter = 0;
+        public long InboundCounter => Interlocked.Read(ref _inboundCounter);
+        public long OutboundCounter => Interlocked.Read(ref _outboundCounter);
         public QueueLast<TrafficPerSecond> traffic;
 
         private bool stopped = false;
@@ -364,7 +366,7 @@ namespace Shadowsocks.Controller
 
         public void UpdateInboundCounter(Server server, long n)
         {
-            Interlocked.Add(ref inboundCounter, n);
+            Interlocked.Add(ref _inboundCounter, n);
             if (_config.availabilityStatistics)
             {
                 availabilityStatistics.UpdateInboundCounter(server, n);
@@ -373,7 +375,7 @@ namespace Shadowsocks.Controller
 
         public void UpdateOutboundCounter(Server server, long n)
         {
-            Interlocked.Add(ref outboundCounter, n);
+            Interlocked.Add(ref _outboundCounter, n);
             if (_config.availabilityStatistics)
             {
                 availabilityStatistics.UpdateOutboundCounter(server, n);
@@ -579,19 +581,17 @@ namespace Shadowsocks.Controller
             {
                 TrafficPerSecond previous = traffic.Last;
                 TrafficPerSecond current = new TrafficPerSecond();
-                current.inboundCounter = inboundCounter;
-                current.outboundCounter = outboundCounter;
-                current.inboundIncreasement = inboundCounter - previous.inboundCounter;
-                current.outboundIncreasement = outboundCounter - previous.outboundCounter;
+                
+                var inbound = current.inboundCounter = InboundCounter;
+                var outbound = current.outboundCounter = OutboundCounter;
+                current.inboundIncreasement = inbound - previous.inboundCounter;
+                current.outboundIncreasement = outbound - previous.outboundCounter;
 
                 traffic.Enqueue(current);
                 if (traffic.Count > queueMaxSize)
                     traffic.Dequeue();
 
-                if (TrafficChanged != null)
-                {
-                    TrafficChanged(this, new EventArgs());
-                }
+                TrafficChanged?.Invoke(this, new EventArgs());
 
                 Thread.Sleep(1000);
             }

--- a/shadowsocks-csharp/View/LogForm.cs
+++ b/shadowsocks-csharp/View/LogForm.cs
@@ -171,7 +171,7 @@ namespace Shadowsocks.View
             }
 
             this.Text = I18N.GetString("Log Viewer") +
-                $" [in: {Utils.FormatBandwidth(controller.inboundCounter)}, out: {Utils.FormatBandwidth(controller.outboundCounter)}]";
+                $" [in: {Utils.FormatBandwidth(controller.InboundCounter)}, out: {Utils.FormatBandwidth(controller.OutboundCounter)}]";
         }
 
         private void LogForm_Load(object sender, EventArgs e)


### PR DESCRIPTION
Use lock to sync between threads.This should fix issue #679 
and other same issue.

Fix a bug in UpdateSpeed() that only save the first xxxSpeedRecord.
This bug was introduced in commit 2aa0620