### PR TITLE
Assign SelectedIndex of ServerListBox only when it is range

### DIFF
--- a/shadowsocks-csharp/View/ConfigForm.cs
+++ b/shadowsocks-csharp/View/ConfigForm.cs
@@ -151,7 +151,7 @@ namespace Shadowsocks.View
             _modifiedConfiguration = controller.GetConfigurationCopy();
             LoadConfiguration(_modifiedConfiguration);
             _lastSelectedIndex = _modifiedConfiguration.index;
-            if (_lastSelectedIndex < 0)
+            if (0 <= _lastSelectedIndex && _lastSelectedIndex < ServersListBox.Items.Count)
             {
                 _lastSelectedIndex = 0;
             }


### PR DESCRIPTION
Bug fix.
This could make shadowsocks crashed if _lastSelectedIndex is changed and not in range.