### PR TITLE
Chart Refactor

### DIFF
--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -13,6 +13,7 @@ using Shadowsocks.Controller.Strategy;
 using Shadowsocks.Model;
 using Shadowsocks.Properties;
 using Shadowsocks.Util;
+using System.Linq;
 
 namespace Shadowsocks.Controller
 {
@@ -39,7 +40,7 @@ namespace Shadowsocks.Controller
         private long _outboundCounter = 0;
         public long InboundCounter => Interlocked.Read(ref _inboundCounter);
         public long OutboundCounter => Interlocked.Read(ref _outboundCounter);
-        public QueueLast<TrafficPerSecond> trafficPerSecondQueue;
+        public Queue<TrafficPerSecond> trafficPerSecondQueue;
 
         private bool stopped = false;
 
@@ -48,16 +49,6 @@ namespace Shadowsocks.Controller
         public class PathEventArgs : EventArgs
         {
             public string Path;
-        }
-
-        public class QueueLast<T> : Queue<T>
-        {
-            public T Last { get; private set; }
-            public new void Enqueue(T item)
-            {
-                Last = item;
-                base.Enqueue(item);
-            }
         }
 
         public class TrafficPerSecond
@@ -621,7 +612,7 @@ namespace Shadowsocks.Controller
 
         private void StartTrafficStatistics(int queueMaxSize)
         {
-            trafficPerSecondQueue = new QueueLast<TrafficPerSecond>();
+            trafficPerSecondQueue = new Queue<TrafficPerSecond>();
             for (int i = 0; i < queueMaxSize; i++)
             {
                 trafficPerSecondQueue.Enqueue(new TrafficPerSecond());
@@ -636,7 +627,7 @@ namespace Shadowsocks.Controller
             TrafficPerSecond previous, current;
             while (true)
             {
-                previous = trafficPerSecondQueue.Last;
+                previous = trafficPerSecondQueue.Last();
                 current = new TrafficPerSecond();
                 
                 current.inboundCounter = InboundCounter;

--- a/shadowsocks-csharp/Util/Util.cs
+++ b/shadowsocks-csharp/Util/Util.cs
@@ -12,13 +12,13 @@ namespace Shadowsocks.Util
     public struct BandwidthScaleInfo
     {
         public float value;
-        public string unit_name;
+        public string unitName;
         public long unit;
 
-        public BandwidthScaleInfo(float value, string unit_name, long unit)
+        public BandwidthScaleInfo(float value, string unitName, long unit)
         {
             this.value = value;
-            this.unit_name = unit_name;
+            this.unitName = unitName;
             this.unit = unit;
         }
     }
@@ -111,7 +111,7 @@ namespace Shadowsocks.Util
         public static string FormatBandwidth(long n)
         {
             var result = GetBandwidthScale(n);
-            return $"{result.value:0.##}{result.unit_name}";
+            return $"{result.value:0.##}{result.unitName}";
         }
 
         public static string FormatBytes(long bytes)

--- a/shadowsocks-csharp/View/LogForm.cs
+++ b/shadowsocks-csharp/View/LogForm.cs
@@ -14,18 +14,6 @@ using System.Text;
 
 namespace Shadowsocks.View
 {
-    public class TrafficInfo
-    {
-        public long inbound;
-        public long outbound;
-
-        public TrafficInfo(long inbound, long outbound)
-        {
-            this.inbound = inbound;
-            this.outbound = outbound;
-        }
-    }
-
     public partial class LogForm : Form
     {
         long lastOffset;
@@ -431,6 +419,18 @@ namespace Shadowsocks.View
             toolbarTrigger = !toolbarTrigger;
             ToolbarFlowLayoutPanel.Visible = toolbarTrigger;
             ShowToolbarMenuItem.Checked = toolbarTrigger;
+        }
+
+        private class TrafficInfo
+        {
+            public long inbound;
+            public long outbound;
+
+            public TrafficInfo(long inbound, long outbound)
+            {
+                this.inbound = inbound;
+                this.outbound = outbound;
+            }
         }
     }
 }

--- a/shadowsocks-csharp/View/LogForm.cs
+++ b/shadowsocks-csharp/View/LogForm.cs
@@ -39,7 +39,7 @@ namespace Shadowsocks.View
 
         #region chart
         long lastMaxSpeed;
-        ShadowsocksController.QueueLast<TrafficInfo> traffic = new ShadowsocksController.QueueLast<TrafficInfo>();
+        ShadowsocksController.QueueLast<TrafficInfo> trafficInfoQueue = new ShadowsocksController.QueueLast<TrafficInfo>();
         #endregion
 
         public LogForm(ShadowsocksController controller, string filename)
@@ -76,16 +76,16 @@ namespace Shadowsocks.View
 
             lock (_lock)
             {
-                if (traffic.Count == 0)
+                if (trafficInfoQueue.Count == 0)
                     return;
-                foreach (var trafficPerSecond in traffic)
+                foreach (var trafficPerSecond in trafficInfoQueue)
                 {
                     inboundPoints.Add(trafficPerSecond.inbound);
                     outboundPoints.Add(trafficPerSecond.outbound);
                     maxSpeed = Math.Max(maxSpeed, Math.Max(trafficPerSecond.inbound, trafficPerSecond.outbound));
                 }
-                lastInbound = traffic.Last().inbound;
-                lastOutbound = traffic.Last().outbound;
+                lastInbound = trafficInfoQueue.Last().inbound;
+                lastOutbound = trafficInfoQueue.Last().outbound;
             }
 
             if (maxSpeed > 0)
@@ -125,10 +125,11 @@ namespace Shadowsocks.View
         {
             lock (_lock)
             {
-                traffic = new ShadowsocksController.QueueLast<TrafficInfo>();
-                foreach (var trafficPerSecond in controller.traffic)
+                trafficInfoQueue = new ShadowsocksController.QueueLast<TrafficInfo>();
+                foreach (var trafficPerSecond in controller.trafficPerSecondQueue)
                 {
-                    traffic.Enqueue(new TrafficInfo(trafficPerSecond.inboundIncreasement, trafficPerSecond.outboundIncreasement));
+                    trafficInfoQueue.Enqueue(new TrafficInfo(trafficPerSecond.inboundIncreasement,
+                                                    trafficPerSecond.outboundIncreasement));
                 }
             }
         }

--- a/shadowsocks-csharp/View/LogForm.cs
+++ b/shadowsocks-csharp/View/LogForm.cs
@@ -39,7 +39,7 @@ namespace Shadowsocks.View
 
         #region chart
         long lastMaxSpeed;
-        ShadowsocksController.QueueLast<TrafficInfo> trafficInfoQueue = new ShadowsocksController.QueueLast<TrafficInfo>();
+        Queue<TrafficInfo> trafficInfoQueue = new Queue<TrafficInfo>();
         #endregion
 
         public LogForm(ShadowsocksController controller, string filename)
@@ -125,7 +125,7 @@ namespace Shadowsocks.View
         {
             lock (_lock)
             {
-                trafficInfoQueue = new ShadowsocksController.QueueLast<TrafficInfo>();
+                trafficInfoQueue = new Queue<TrafficInfo>();
                 foreach (var trafficPerSecond in controller.trafficPerSecondQueue)
                 {
                     trafficInfoQueue.Enqueue(new TrafficInfo(trafficPerSecond.inboundIncreasement,

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -13,6 +13,7 @@ using Shadowsocks.Controller;
 using Shadowsocks.Model;
 using Shadowsocks.Properties;
 using Shadowsocks.Util;
+using System.Linq;
 
 namespace Shadowsocks.View
 {
@@ -112,8 +113,8 @@ namespace Shadowsocks.View
 
             Icon newIcon;
 
-            bool hasInbound = controller.trafficPerSecondQueue.Last.inboundIncreasement > 0;
-            bool hasOutbound = controller.trafficPerSecondQueue.Last.outboundIncreasement > 0;
+            bool hasInbound = controller.trafficPerSecondQueue.Last().inboundIncreasement > 0;
+            bool hasOutbound = controller.trafficPerSecondQueue.Last().outboundIncreasement > 0;
 
             if (hasInbound && hasOutbound)
                 newIcon = icon_both;

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -112,8 +112,8 @@ namespace Shadowsocks.View
 
             Icon newIcon;
 
-            bool hasInbound = controller.traffic.Last.inboundIncreasement > 0;
-            bool hasOutbound = controller.traffic.Last.outboundIncreasement > 0;
+            bool hasInbound = controller.trafficPerSecondQueue.Last.inboundIncreasement > 0;
+            bool hasOutbound = controller.trafficPerSecondQueue.Last.outboundIncreasement > 0;
 
             if (hasInbound && hasOutbound)
                 newIcon = icon_both;


### PR DESCRIPTION
- Rename variable 'traffic' to 'trafficPerSecondQueue' and 'trafficInfoQueue'
- Remove class QueueLast<T> by using linq Queue.Last()
- Slight changes, such as rename, move several variables from function domain to class domain to improve performance. Logic remains the same.
- Update the logic of copying queue from Controller to View.