### PR TITLE
Add an option to enable to using system temp folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ if you want to deactivate all, please clear all textboxes.
 
 Please visit [Servers] for more information.
 
+#### Use System Temp Folder		
+		
+ If you want to put all temporary files into system temp folder instead of		
+ shadowsocks/ss_win_temp folder, create a `use_system_temp_folder.txt` into shadowsocks folder.
+ You need restarting Shadowsocks to make the change effective.
+ 
 #### Develop
 
 [Visual Studio 2015] & [.NET Framework 4.6.2 Developer Pack] are required.

--- a/shadowsocks-csharp/Controller/Service/PrivoxyRunner.cs
+++ b/shadowsocks-csharp/Controller/Service/PrivoxyRunner.cs
@@ -121,12 +121,21 @@ namespace Shadowsocks.Controller
         {
             try
             {
-                /*
-                 * Under PortableMode, we could identify it by the path of ss_privoxy.exe.
-                 */
-                var path = process.MainModule.FileName;
+                bool isPortable = ! Utils.GetTempPath().Equals(Path.GetTempPath());
+                if (isPortable)
+                {
+                    /*
+                     * Under PortableMode, we could identify it by the path of ss_privoxy.exe.
+                     */
+                    var path = process.MainModule.FileName;
 
-                return Utils.GetTempPath("ss_privoxy.exe").Equals(path);
+                    return Utils.GetTempPath("ss_privoxy.exe").Equals(path);
+                }
+                else
+                {
+                    var cmd = process.GetCommandLine();
+                    return cmd.Contains(_uniqueConfigFile);
+                }
 
             }
             catch (Exception ex)

--- a/shadowsocks-csharp/Util/Util.cs
+++ b/shadowsocks-csharp/Util/Util.cs
@@ -34,9 +34,17 @@ namespace Shadowsocks.Util
             {
                 try
                 {
-                    Directory.CreateDirectory(Path.Combine(Application.StartupPath, "ss_win_temp"));
-                    // don't use "/", it will fail when we call explorer /select xxx/ss_win_temp\xxx.log
-                    _tempPath = Path.Combine(Application.StartupPath, "ss_win_temp");
+                    bool nonportable = File.Exists(Path.Combine(Application.StartupPath, "use_system_temp_folder.txt"));
+                    if (nonportable)
+                    {
+                        _tempPath = Path.GetTempPath();
+                    }
+                    else
+                    {
+                        Directory.CreateDirectory(Path.Combine(Application.StartupPath, "ss_win_temp"));
+                        // don't use "/", it will fail when we call explorer /select xxx/ss_win_temp\xxx.log
+                        _tempPath = Path.Combine(Application.StartupPath, "ss_win_temp");
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
To solve issues like #1022.
Now users can choose to put temp files into system temp folder.

Only see the files changes in commit 4c49f1b73637d778dd76f76845f2f0c92dbbf6f8, which makes the  portable mode as default. 
Not read all codes, so may have bugs.
Build and run on my PC in x86 debug mode successfully.