### PR TITLE
When system is shutting down, the proxy should be unset

### DIFF
--- a/shadowsocks-csharp/Program.cs
+++ b/shadowsocks-csharp/Program.cs
@@ -189,8 +189,12 @@ namespace Shadowsocks
         {
             // Force disable proxy before exiting 
             // We can't use Sysproxy here since it won't work when session is ending.
-            RegistryKey registryKey = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
-            registryKey.SetValue("ProxyEnable", 0);
+            var proxyRegistryKey 
+                = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings", true);
+
+            // Disable proxy by setting ProxyEnable to 0 and deleting PAC.
+            proxyRegistryKey?.SetValue("ProxyEnable", 0);
+            proxyRegistryKey?.DeleteValue("AutoConfigURL");
 
             // Remove other event in case something goes wrong in the next boot later on
             Application.ApplicationExit -= Application_ApplicationExit;


### PR DESCRIPTION
Hello all,

I've found that when the system is shutting down, and shadowsocks app is killed but the proxy is still remain set improperly. When the system boot again later, the network is disconnected because Shadowsocks is not running. 

So the best way is to add a  [SystemEvents.SessionEnding](https://msdn.microsoft.com/en-us/library/microsoft.win32.systemevents.sessionending(v=vs.110).aspx) event and a event handler method to detect the user log out / shutdown behaviour and force unset the proxy when it happens.

Hope it helps anyway.

Regards,
Jackson