### PR TITLE
对正向HTTP代理添加基本认证功能

### DIFF
--- a/shadowsocks-csharp/Controller/Service/TCPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/TCPRelay.cs
@@ -681,9 +681,16 @@ namespace Shadowsocks.Controller
                 connectTimer.Server = server;
 
                 _destConnected = false;
+
+                NetworkCredential auth = null;
+                if (_config.proxy.useAuth)
+                {
+                    auth = new NetworkCredential(_config.proxy.authUser, _config.proxy.authPwd);
+                }
+
                 // Connect to the remote endpoint.
                 remote.BeginConnectDest(destEndPoint, ConnectCallback,
-                    new AsyncSession<ServerTimer>(session, connectTimer));
+                    new AsyncSession<ServerTimer>(session, connectTimer), auth);
             }
             catch (ArgumentException)
             {

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -222,6 +222,20 @@ namespace Shadowsocks.Controller
             _config.proxy.proxyServer = proxy;
             _config.proxy.proxyPort = port;
             _config.proxy.proxyTimeout = timeout;
+            _config.proxy.useAuth = false;
+            SaveConfig(_config);
+        }
+
+        public void EnableProxyWithAuth(int type, string proxy, int port, int timeout, string user, string pwd)
+        {
+            _config.proxy.useProxy = true;
+            _config.proxy.proxyType = type;
+            _config.proxy.proxyServer = proxy;
+            _config.proxy.proxyPort = port;
+            _config.proxy.proxyTimeout = timeout;
+            _config.proxy.useAuth = true;
+            _config.proxy.authUser = user;
+            _config.proxy.authPwd = pwd;
             SaveConfig(_config);
         }
 

--- a/shadowsocks-csharp/Data/ja.txt
+++ b/shadowsocks-csharp/Data/ja.txt
@@ -66,6 +66,9 @@ Use Proxy=プロキシを利用する
 Proxy Type=プロキシの種類
 Proxy Addr=プロキシアドレス
 Proxy Port=プロキシポート
+Use Auth=認証を利用する
+Auth User=認証ユーザ
+Auth Pwd=認証パスワード
 
 # Log Form
 
@@ -140,3 +143,5 @@ Proxy handshake failed=プロキシ ハンドシェイクに失敗しました�
 Register hotkey failed=ホットキーの登錄に失敗しました。
 Cannot parse hotkey: {0}=ホットキーを解析できません: {0}
 Timeout is invalid, it should not exceed {0}=タイムアウト値が無効です。{0} 以下の値を指定して下さい。
+Auth user can not be blank=認証ユーザが指定されていません。
+Auth pwd can not be blank=認証パスワードが指定されていません。

--- a/shadowsocks-csharp/Data/zh_CN.txt
+++ b/shadowsocks-csharp/Data/zh_CN.txt
@@ -66,6 +66,9 @@ Use Proxy=使用代理
 Proxy Type=代理类型
 Proxy Addr=代理地址
 Proxy Port=代理端口
+Use Auth=使用认证
+Auth User=认证用户
+Auth Pwd=认证密码
 
 # Log Form
 
@@ -140,3 +143,5 @@ Proxy handshake failed=代理握手失败
 Register hotkey failed=注册热键失败
 Cannot parse hotkey: {0}=解析热键失败: {0}
 Timeout is invalid, it should not exceed {0}=超时无效，不应超过 {0}
+Auth user can not be blank=认证用户不能为空
+Auth pwd can not be blank=认证密码不能为空

--- a/shadowsocks-csharp/Data/zh_TW.txt
+++ b/shadowsocks-csharp/Data/zh_TW.txt
@@ -66,6 +66,9 @@ Use Proxy=使用 Proxy
 Proxy Type=Proxy 類型
 Proxy Addr=Proxy 位址
 Proxy Port=Proxy 連接埠
+Use Auth=使用認證
+Auth User=認證用戶
+Auth Pwd=認證口令
 
 # Log Form
 
@@ -140,3 +143,5 @@ Proxy handshake failed=Proxy 交握失敗
 Register hotkey failed=註冊快速鍵失敗
 Cannot parse hotkey: {0}=剖析快速鍵失敗: {0}
 Timeout is invalid, it should not exceed {0}=逾時無效，不應超過 {0}
+Auth user can not be blank=認證用戶不能為空
+Auth pwd can not be blank=認證口令不能為空

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -160,5 +160,17 @@ namespace Shadowsocks.Model
                 throw new ArgumentException(string.Format(
                     I18N.GetString("Timeout is invalid, it should not exceed {0}"), maxTimeout));
         }
+
+        public static void CheckProxyAuthUser(string user)
+        {
+            if (user.IsNullOrEmpty())
+                throw new ArgumentException(I18N.GetString("Auth user can not be blank"));
+        }
+
+        public static void CheckProxyAuthPwd(string pwd)
+        {
+            if (pwd.IsNullOrEmpty())
+                throw new ArgumentException(I18N.GetString("Auth pwd can not be blank"));
+        }
     }
 }

--- a/shadowsocks-csharp/Model/ProxyConfig.cs
+++ b/shadowsocks-csharp/Model/ProxyConfig.cs
@@ -16,6 +16,9 @@ namespace Shadowsocks.Model
         public string proxyServer;
         public int proxyPort;
         public int proxyTimeout;
+        public bool useAuth;
+        public string authUser;
+        public string authPwd;
 
         public ProxyConfig()
         {
@@ -24,6 +27,9 @@ namespace Shadowsocks.Model
             proxyServer = "";
             proxyPort = 0;
             proxyTimeout = DefaultProxyTimeoutSec;
+            useAuth = false;
+            authUser = "";
+            authPwd = "";
         }
 
         public void CheckConfig()

--- a/shadowsocks-csharp/Proxy/DirectConnect.cs
+++ b/shadowsocks-csharp/Proxy/DirectConnect.cs
@@ -51,7 +51,7 @@ namespace Shadowsocks.Proxy
             // do nothing
         }
 
-        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state)
+        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state, NetworkCredential auth = null)
         {
             DestEndPoint = destEndPoint;
 

--- a/shadowsocks-csharp/Proxy/HttpProxy.cs
+++ b/shadowsocks-csharp/Proxy/HttpProxy.cs
@@ -68,12 +68,21 @@ namespace Shadowsocks.Proxy
             "Host: {0}" + HTTP_CRLF +
             "Proxy-Connection: keep-alive" + HTTP_CRLF +
             "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36" + HTTP_CRLF +
+            "{1}" +         // Proxy-Authorization if any
             "" + HTTP_CRLF; // End with an empty line
+        private const string PROXY_AUTH_TEMPLATE = "Proxy-Authorization: Basic {0}" + HTTP_CRLF;
 
-        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state)
+        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state, NetworkCredential auth = null)
         {
             DestEndPoint = destEndPoint;
-            string request = string.Format(HTTP_CONNECT_TEMPLATE, destEndPoint);
+
+            String authInfo = "";
+            if (auth != null)
+            {
+                string authKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(auth.UserName + ":" + auth.Password));
+                authInfo = string.Format(PROXY_AUTH_TEMPLATE, authKey);
+            }
+            string request = string.Format(HTTP_CONNECT_TEMPLATE, destEndPoint, authInfo);
 
             var b = Encoding.UTF8.GetBytes(request);
 

--- a/shadowsocks-csharp/Proxy/IProxy.cs
+++ b/shadowsocks-csharp/Proxy/IProxy.cs
@@ -17,7 +17,7 @@ namespace Shadowsocks.Proxy
 
         void EndConnectProxy(IAsyncResult asyncResult);
 
-        void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state);
+        void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state, NetworkCredential auth = null);
 
         void EndConnectDest(IAsyncResult asyncResult);
 

--- a/shadowsocks-csharp/Proxy/Socks5Proxy.cs
+++ b/shadowsocks-csharp/Proxy/Socks5Proxy.cs
@@ -69,8 +69,10 @@ namespace Shadowsocks.Proxy
             }
         }
 
-        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state)
+        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state, NetworkCredential auth = null)
         {
+            // TODO support for SOCK5 auth
+
             DestEndPoint = destEndPoint;
 
             byte[] request = null;

--- a/shadowsocks-csharp/View/ProxyForm.Designer.cs
+++ b/shadowsocks-csharp/View/ProxyForm.Designer.cs
@@ -43,10 +43,17 @@
             this.ProxyTypeComboBox = new System.Windows.Forms.ComboBox();
             this.ProxyTimeoutTextBox = new System.Windows.Forms.TextBox();
             this.ProxyTimeoutLabel = new System.Windows.Forms.Label();
+            this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
+            this.AuthUserLabel = new System.Windows.Forms.Label();
+            this.AuthUserTextBox = new System.Windows.Forms.TextBox();
+            this.AuthPwdLabel = new System.Windows.Forms.Label();
+            this.AuthPwdTextBox = new System.Windows.Forms.TextBox();
+            this.UseAuthCheckBox = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
             this.tableLayoutPanel4.SuspendLayout();
+            this.tableLayoutPanel5.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -55,18 +62,22 @@
             this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel1.ColumnCount = 1;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel3, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel3, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.UseProxyCheckBox, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel4, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel5, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.UseAuthCheckBox, 0, 3);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(15, 15);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 4;
+            this.tableLayoutPanel1.RowCount = 6;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(395, 123);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(442, 178);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // tableLayoutPanel3
@@ -80,7 +91,7 @@
             this.tableLayoutPanel3.Controls.Add(this.MyCancelButton, 1, 0);
             this.tableLayoutPanel3.Controls.Add(this.OKButton, 0, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Right;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(236, 94);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(283, 149);
             this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(3, 3, 0, 3);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 1;
@@ -142,7 +153,7 @@
             this.tableLayoutPanel2.RowCount = 1;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 27F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(389, 27);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(424, 27);
             this.tableLayoutPanel2.TabIndex = 1;
             // 
             // ProxyAddrLabel
@@ -181,7 +192,7 @@
             this.ProxyPortTextBox.Location = new System.Drawing.Point(286, 3);
             this.ProxyPortTextBox.MaxLength = 10;
             this.ProxyPortTextBox.Name = "ProxyPortTextBox";
-            this.ProxyPortTextBox.Size = new System.Drawing.Size(100, 21);
+            this.ProxyPortTextBox.Size = new System.Drawing.Size(135, 21);
             this.ProxyPortTextBox.TabIndex = 3;
             this.ProxyPortTextBox.WordWrap = false;
             // 
@@ -201,7 +212,7 @@
             this.tableLayoutPanel4.Name = "tableLayoutPanel4";
             this.tableLayoutPanel4.RowCount = 1;
             this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel4.Size = new System.Drawing.Size(387, 30);
+            this.tableLayoutPanel4.Size = new System.Drawing.Size(436, 30);
             this.tableLayoutPanel4.TabIndex = 10;
             // 
             // ProxyTypeLabel
@@ -225,26 +236,99 @@
             this.ProxyTypeComboBox.Location = new System.Drawing.Point(74, 5);
             this.ProxyTypeComboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.ProxyTypeComboBox.Name = "ProxyTypeComboBox";
-            this.ProxyTypeComboBox.Size = new System.Drawing.Size(121, 20);
+            this.ProxyTypeComboBox.Size = new System.Drawing.Size(135, 20);
             this.ProxyTypeComboBox.TabIndex = 2;
+            this.ProxyTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.ProxyTypeComboBox_SelectedIndexChanged);
             // 
             // ProxyTimeoutTextBox
             // 
             this.ProxyTimeoutTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.ProxyTimeoutTextBox.Location = new System.Drawing.Point(284, 4);
+            this.ProxyTimeoutTextBox.Location = new System.Drawing.Point(298, 4);
             this.ProxyTimeoutTextBox.Name = "ProxyTimeoutTextBox";
-            this.ProxyTimeoutTextBox.Size = new System.Drawing.Size(100, 21);
+            this.ProxyTimeoutTextBox.Size = new System.Drawing.Size(135, 21);
             this.ProxyTimeoutTextBox.TabIndex = 3;
             // 
             // ProxyTimeoutLabel
             // 
             this.ProxyTimeoutLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.ProxyTimeoutLabel.AutoSize = true;
-            this.ProxyTimeoutLabel.Location = new System.Drawing.Point(201, 9);
+            this.ProxyTimeoutLabel.Location = new System.Drawing.Point(215, 9);
             this.ProxyTimeoutLabel.Name = "ProxyTimeoutLabel";
             this.ProxyTimeoutLabel.Size = new System.Drawing.Size(77, 12);
             this.ProxyTimeoutLabel.TabIndex = 4;
             this.ProxyTimeoutLabel.Text = "Timeout(Sec)";
+            // 
+            // tableLayoutPanel5
+            // 
+            this.tableLayoutPanel5.AutoSize = true;
+            this.tableLayoutPanel5.ColumnCount = 4;
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel5.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel5.Controls.Add(this.AuthUserLabel, 0, 0);
+            this.tableLayoutPanel5.Controls.Add(this.AuthUserTextBox, 1, 0);
+            this.tableLayoutPanel5.Controls.Add(this.AuthPwdLabel, 2, 0);
+            this.tableLayoutPanel5.Controls.Add(this.AuthPwdTextBox, 3, 0);
+            this.tableLayoutPanel5.Location = new System.Drawing.Point(3, 116);
+            this.tableLayoutPanel5.Name = "tableLayoutPanel5";
+            this.tableLayoutPanel5.RowCount = 1;
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel5.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 27F));
+            this.tableLayoutPanel5.Size = new System.Drawing.Size(406, 27);
+            this.tableLayoutPanel5.TabIndex = 1;
+            // 
+            // AuthUserLabel
+            // 
+            this.AuthUserLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.AuthUserLabel.AutoSize = true;
+            this.AuthUserLabel.Location = new System.Drawing.Point(3, 7);
+            this.AuthUserLabel.Name = "AuthUserLabel";
+            this.AuthUserLabel.Size = new System.Drawing.Size(59, 12);
+            this.AuthUserLabel.TabIndex = 0;
+            this.AuthUserLabel.Text = "Auth User";
+            // 
+            // AuthUserTextBox
+            // 
+            this.AuthUserTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.AuthUserTextBox.Location = new System.Drawing.Point(68, 3);
+            this.AuthUserTextBox.MaxLength = 512;
+            this.AuthUserTextBox.Name = "AuthUserTextBox";
+            this.AuthUserTextBox.Size = new System.Drawing.Size(135, 21);
+            this.AuthUserTextBox.TabIndex = 1;
+            this.AuthUserTextBox.WordWrap = false;
+            // 
+            // AuthPwdLabel
+            // 
+            this.AuthPwdLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.AuthPwdLabel.AutoSize = true;
+            this.AuthPwdLabel.Location = new System.Drawing.Point(209, 7);
+            this.AuthPwdLabel.Name = "AuthPwdLabel";
+            this.AuthPwdLabel.Size = new System.Drawing.Size(53, 12);
+            this.AuthPwdLabel.TabIndex = 2;
+            this.AuthPwdLabel.Text = "Auth Pwd";
+            // 
+            // AuthPwdTextBox
+            // 
+            this.AuthPwdTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.AuthPwdTextBox.Location = new System.Drawing.Point(268, 3);
+            this.AuthPwdTextBox.MaxLength = 512;
+            this.AuthPwdTextBox.Name = "AuthPwdTextBox";
+            this.AuthPwdTextBox.Size = new System.Drawing.Size(135, 21);
+            this.AuthPwdTextBox.TabIndex = 3;
+            this.AuthPwdTextBox.UseSystemPasswordChar = true;
+            this.AuthPwdTextBox.WordWrap = false;
+            // 
+            // UseAuthCheckBox
+            // 
+            this.UseAuthCheckBox.AutoSize = true;
+            this.UseAuthCheckBox.Location = new System.Drawing.Point(3, 94);
+            this.UseAuthCheckBox.Name = "UseAuthCheckBox";
+            this.UseAuthCheckBox.Size = new System.Drawing.Size(72, 16);
+            this.UseAuthCheckBox.TabIndex = 0;
+            this.UseAuthCheckBox.Text = "Use Auth";
+            this.UseAuthCheckBox.UseVisualStyleBackColor = true;
+            this.UseAuthCheckBox.CheckedChanged += new System.EventHandler(this.UseAuthCheckBox_CheckedChanged);
             // 
             // ProxyForm
             // 
@@ -254,7 +338,7 @@
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.CancelButton = this.MyCancelButton;
-            this.ClientSize = new System.Drawing.Size(441, 165);
+            this.ClientSize = new System.Drawing.Size(472, 211);
             this.Controls.Add(this.tableLayoutPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MaximizeBox = false;
@@ -271,6 +355,8 @@
             this.tableLayoutPanel2.PerformLayout();
             this.tableLayoutPanel4.ResumeLayout(false);
             this.tableLayoutPanel4.PerformLayout();
+            this.tableLayoutPanel5.ResumeLayout(false);
+            this.tableLayoutPanel5.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -293,5 +379,11 @@
         private System.Windows.Forms.ComboBox ProxyTypeComboBox;
         private System.Windows.Forms.TextBox ProxyTimeoutTextBox;
         private System.Windows.Forms.Label ProxyTimeoutLabel;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel5;
+        private System.Windows.Forms.Label AuthUserLabel;
+        private System.Windows.Forms.TextBox AuthUserTextBox;
+        private System.Windows.Forms.Label AuthPwdLabel;
+        private System.Windows.Forms.TextBox AuthPwdTextBox;
+        private System.Windows.Forms.CheckBox UseAuthCheckBox;
     }
 }


### PR DESCRIPTION
对正向HTTP代理，添加了对基本认证（Basic access authentication）的支持：
![http proxy](https://user-images.githubusercontent.com/25237525/27816462-413ac476-60be-11e7-9d6c-18e29d00b26c.png)

暂未提供对正向SOCKS5代理的认证支持，选择SOCKS5类型时，认证信息设置控件不可用：
![sock5 proxy](https://user-images.githubusercontent.com/25237525/27816514-9b51e05c-60be-11e7-861f-3f77356d4823.png)
