### PR TITLE
add requirement for .NET 4.6.2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Shadowsocks for Windows
 
 Download the [latest release].
 
+#### Requirements
+
+If you use Windows 7, you need Microsoft [.NET Framework 4.6.2](https://www.microsoft.com/en-US/download/details.aspx?id=53344) or higher. 
+
 #### Basic
 
 1. Find Shadowsocks icon in the notification tray

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Download the [latest release].
 
 #### Requirements
 
-If you use Windows 7, you need Microsoft [.NET Framework 4.6.2](https://www.microsoft.com/en-US/download/details.aspx?id=53344) or higher. 
+Microsoft [.NET Framework 4.6.2](https://www.microsoft.com/en-US/download/details.aspx?id=53344) or higher. 
 
 #### Basic
 


### PR DESCRIPTION
I tried shadowsocks on Windows 7. However, it didn't work well until I install Microsoft .NET Framework 4.6.2.