### PR TITLE
Fixing issues with "4.0.4 null exceptions" at launch for certain users

### DIFF
--- a/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
+++ b/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
@@ -48,7 +48,12 @@ namespace Shadowsocks.Util.SystemProxy
         public static void SetIEProxy(bool enable, bool global, string proxyServer, string pacURL)
         {
             Read();
-            if (_userSettings == null || !_userSettings.UserSettingsRecorded)
+            if (_userSettings == null)
+            {
+              _userSettings = new SysproxyConfig();
+            }
+
+            if (!_userSettings.UserSettingsRecorded)
             {
                 // record user settings
                 ExecSysproxy("query");

--- a/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
+++ b/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
@@ -48,14 +48,14 @@ namespace Shadowsocks.Util.SystemProxy
         public static void SetIEProxy(bool enable, bool global, string proxyServer, string pacURL)
         {
             Read();
-            if (!_userSettings.UserSettingsRecorded)
+            if (_userSettings == null || !_userSettings.UserSettingsRecorded)
             {
                 // record user settings
                 ExecSysproxy("query");
                 ParseQueryStr(_queryStr);
             }
-            string arguments;
 
+            string arguments;
             if (enable)
             {
                 arguments = global
@@ -140,6 +140,8 @@ namespace Shadowsocks.Util.SystemProxy
                 _userSettings = JsonConvert.DeserializeObject<SysproxyConfig>(configContent);
             } catch (FileNotFoundException) {
                 _userSettings = new SysproxyConfig();
+            } finally {
+                _userSettings = (_userSettings == null) ? new SysproxyConfig() : _userSettings;
             }
         }
 

--- a/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
+++ b/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
@@ -48,10 +48,6 @@ namespace Shadowsocks.Util.SystemProxy
         public static void SetIEProxy(bool enable, bool global, string proxyServer, string pacURL)
         {
             Read();
-            if (_userSettings == null)
-            {
-              _userSettings = new SysproxyConfig();
-            }
 
             if (!_userSettings.UserSettingsRecorded)
             {
@@ -143,10 +139,10 @@ namespace Shadowsocks.Util.SystemProxy
             try {
                 string configContent = File.ReadAllText(_userWininetConfigFile);
                 _userSettings = JsonConvert.DeserializeObject<SysproxyConfig>(configContent);
-            } catch (FileNotFoundException) {
-                _userSettings = new SysproxyConfig();
+            } catch(Exception) {
+               // Suppress all exceptions. finally block will initialize new user config settings.
             } finally {
-                _userSettings = (_userSettings == null) ? new SysproxyConfig() : _userSettings;
+                if (_userSettings == null) _userSettings = new SysproxyConfig();
             }
         }
 


### PR DESCRIPTION
Adding rail guard and fallback logic in the initializing logic, where if a user setting is previously null, we could end up with null reference exceptions being thrown. 