### PR TITLE
Use job objects with SIP003 plugin to avoid lingering processes if app is killed

### DIFF
--- a/shadowsocks-csharp/Controller/Service/Sip003Plugin.cs
+++ b/shadowsocks-csharp/Controller/Service/Sip003Plugin.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
 using Shadowsocks.Model;
+using Shadowsocks.Util.ProcessManagement;
 
 namespace Shadowsocks.Controller.Service
 {
@@ -15,6 +16,7 @@ namespace Shadowsocks.Controller.Service
         public int ProcessId => _started ? _pluginProcess.Id : 0;
 
         private readonly object _startProcessLock = new object();
+        private readonly Job _pluginJob;
         private readonly Process _pluginProcess;
         private bool _started;
         private bool _disposed;
@@ -66,6 +68,8 @@ namespace Shadowsocks.Controller.Service
                     }
                 }
             };
+
+            _pluginJob = new Job();
         }
 
         public bool StartIfNeeded()
@@ -88,6 +92,7 @@ namespace Shadowsocks.Controller.Service
                 _pluginProcess.StartInfo.Environment["SS_LOCAL_HOST"] = LocalEndPoint.Address.ToString();
                 _pluginProcess.StartInfo.Environment["SS_LOCAL_PORT"] = LocalEndPoint.Port.ToString();
                 _pluginProcess.Start();
+                _pluginJob.AddProcess(_pluginProcess.Handle);
                 _started = true;
             }
 
@@ -124,6 +129,7 @@ namespace Shadowsocks.Controller.Service
                 try
                 {
                     _pluginProcess.Dispose();
+                    _pluginJob.Dispose();
                 }
                 catch (Exception) { }
 

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -158,10 +158,18 @@ namespace Shadowsocks.Controller
                 return null;
             }
 
-            if (plugin.StartIfNeeded())
+            try
             {
-                Logging.Info(
-                    $"Started SIP003 plugin for {server.Identifier()} on {plugin.LocalEndPoint} - PID: {plugin.ProcessId}");
+                if (plugin.StartIfNeeded())
+                {
+                    Logging.Info(
+                        $"Started SIP003 plugin for {server.Identifier()} on {plugin.LocalEndPoint} - PID: {plugin.ProcessId}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logging.Error("Failed to start SIP003 plugin: " + ex.Message);
+                throw;
             }
 
             return plugin.LocalEndPoint;

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -534,6 +534,7 @@ namespace Shadowsocks.Controller
                     strategy.ReloadServers();
                 }
 
+                StartPlugins();
                 privoxyRunner.Start(_config);
 
                 TCPRelay tcpRelay = new TCPRelay(this, _config);
@@ -569,6 +570,15 @@ namespace Shadowsocks.Controller
 
             UpdateSystemProxy();
             Utils.ReleaseMemory(true);
+        }
+
+        private void StartPlugins()
+        {
+            foreach (var server in _config.configs)
+            {
+                // Early start plugin processes
+                GetPluginLocalEndPointIfConfigured(server);
+            }
         }
 
         protected void SaveConfig(Configuration newConfig)


### PR DESCRIPTION
This is a follow up to #1298. Uses windows job objects with SIP003 processes so that if shadowsocks is killed SIP003 plugin is killed by OS also (instead of lingering processes).

Hoping for a swift review and merge :-)