### PR TITLE
Sip002 refine

### DIFF
--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -329,13 +329,13 @@ namespace Shadowsocks.Controller
             }
         }
 
-        public string GetQRCodeForCurrentServer()
+        public string GetServerURLForCurrentServer()
         {
             Server server = GetCurrentServer();
-            return GetQRCode(server);
+            return GetServerURL(server);
         }
 
-        public static string GetQRCode(Server server)
+        public static string GetServerURL(Server server)
         {
             string tag = string.Empty;
             string url = string.Empty;

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -659,7 +659,7 @@ namespace Shadowsocks.View
 
         private void QRCodeItem_Click(object sender, EventArgs e)
         {
-            QRCodeForm qrCodeForm = new QRCodeForm(controller.GetQRCodeForCurrentServer());
+            QRCodeForm qrCodeForm = new QRCodeForm(controller.GetServerURLForCurrentServer());
             //qrCodeForm.Icon = this.Icon;
             // TODO
             qrCodeForm.Show();

--- a/shadowsocks-csharp/View/QRCodeForm.cs
+++ b/shadowsocks-csharp/View/QRCodeForm.cs
@@ -67,7 +67,7 @@ namespace Shadowsocks.View
             var servers = Configuration.Load();
             var serverDatas = servers.configs.Select(
                 server =>
-                    new KeyValuePair<string, string>(ShadowsocksController.GetQRCode(server), server.FriendlyName())
+                    new KeyValuePair<string, string>(ShadowsocksController.GetServerURL(server), server.FriendlyName())
                 ).ToList();
             listBox1.DataSource = serverDatas;
 

--- a/test/UnitTest.cs
+++ b/test/UnitTest.cs
@@ -436,7 +436,7 @@ namespace test
                 string expected = testCase.Key;
                 Server config = testCase.Value;
 
-                var actual = ShadowsocksController.GetQRCode(config);
+                var actual = ShadowsocksController.GetServerURL(config);
                 Assert.AreEqual(expected, actual);
             }
         }


### PR DESCRIPTION
- Bring back the legacy parser
Needs the legacy Regex pattern to match the legacy standard.
- Refine SIP002 logic
Do not parse the URL userinfo part (`method:password`) by standard .Net URL parser directly because it may contain illegal URL characters.