### PR TITLE
Close sockets before stop plugins

### DIFF
--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -520,7 +520,6 @@ namespace Shadowsocks.Controller
                 _listener.Stop();
             }
 
-            // 
             StopPlugins();
 
             // don't put PrivoxyRunner.Start() before pacServer.Stop()
@@ -536,7 +535,7 @@ namespace Shadowsocks.Controller
                     strategy.ReloadServers();
                 }
 
-                StartPlugins();
+                StartPlugin();
                 privoxyRunner.Start(_config);
 
                 TCPRelay tcpRelay = new TCPRelay(this, _config);
@@ -556,8 +555,7 @@ namespace Shadowsocks.Controller
                 if (e is SocketException)
                 {
                     SocketException se = (SocketException)e;
-                    if (se.SocketErrorCode == SocketError.AccessDenied || 
-                        se.SocketErrorCode == SocketError.AddressAlreadyInUse)
+                    if (se.SocketErrorCode == SocketError.AccessDenied)
                     {
                         e = new Exception(I18N.GetString("Port already in use"), e);
                     }
@@ -575,13 +573,10 @@ namespace Shadowsocks.Controller
             Utils.ReleaseMemory(true);
         }
 
-        private void StartPlugins()
+        private void StartPlugin()
         {
-            foreach (var server in _config.configs)
-            {
-                // Early start plugin processes
-                GetPluginLocalEndPointIfConfigured(server);
-            }
+            var server = _config.GetCurrentServer();
+            GetPluginLocalEndPointIfConfigured(server);
         }
 
         protected void SaveConfig(Configuration newConfig)

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -490,8 +490,6 @@ namespace Shadowsocks.Controller
 
         protected void Reload()
         {
-            StopPlugins();
-
             Encryption.RNG.Reload();
             // some logic in configuration updated the config when saving, we need to read it again
             _config = Configuration.Load();
@@ -521,6 +519,10 @@ namespace Shadowsocks.Controller
             {
                 _listener.Stop();
             }
+
+            // 
+            StopPlugins();
+
             // don't put PrivoxyRunner.Start() before pacServer.Stop()
             // or bind will fail when switching bind address from 0.0.0.0 to 127.0.0.1
             // though UseShellExecute is set to true now
@@ -554,7 +556,8 @@ namespace Shadowsocks.Controller
                 if (e is SocketException)
                 {
                     SocketException se = (SocketException)e;
-                    if (se.SocketErrorCode == SocketError.AccessDenied)
+                    if (se.SocketErrorCode == SocketError.AccessDenied || 
+                        se.SocketErrorCode == SocketError.AddressAlreadyInUse)
                     {
                         e = new Exception(I18N.GetString("Port already in use"), e);
                     }


### PR DESCRIPTION
解决使用SIP003插件时出现的“端口已被占用”问题 #1615 
初步判断是因为先关掉插件导致Reload时Socket无法立刻关闭

手动测试问题已解决，不知道如何进一步测试，待进一步确认
