### PR TITLE
add official way to dump network tracing info

### DIFF
--- a/shadowsocks-csharp/app.config
+++ b/shadowsocks-csharp/app.config
@@ -39,4 +39,49 @@
       </setting>
     </Shadowsocks.Properties.Settings>
   </userSettings>
+  <!--
+    <system.diagnostics>
+    <sources>
+      <source name="System.Net" tracemode="includehex" maxdatasize="1024">
+        <listeners>
+          <add name="System.Net"/>
+        </listeners>
+      </source>
+      <source name="System.Net.Cache">
+        <listeners>
+          <add name="System.Net"/>
+        </listeners>
+      </source>
+      <source name="System.Net.Http">
+        <listeners>
+          <add name="System.Net"/>
+        </listeners>
+      </source>
+      <source name="System.Net.Sockets">
+        <listeners>
+          <add name="System.Net"/>
+        </listeners>
+      </source>
+      <source name="System.Net.WebSockets">
+        <listeners>
+          <add name="System.Net"/>
+        </listeners>
+      </source>
+    </sources>
+    <switches>
+      <add name="System.Net" value="Verbose"/>
+      <add name="System.Net.Cache" value="Verbose"/>
+      <add name="System.Net.Http" value="Verbose"/>
+      <add name="System.Net.Sockets" value="Verbose"/>
+      <add name="System.Net.WebSockets" value="Verbose"/>
+    </switches>
+    <sharedListeners>
+      <add name="System.Net"
+        type="System.Diagnostics.TextWriterTraceListener"
+        initializeData="network-tracing.log"
+      />
+    </sharedListeners>
+    <trace autoflush="true"/>
+  </system.diagnostics>
+  -->
 </configuration>


### PR DESCRIPTION
just uncomment the specific node in app.config, no need to recompile
to take effect. It will be shipped as Shadowsocks.exe.config after built.

This is for debugging only.