### PR TITLE
Optimization warning and StringEx code

### DIFF
--- a/shadowsocks-csharp/Proxy/HttpProxy.cs
+++ b/shadowsocks-csharp/Proxy/HttpProxy.cs
@@ -36,7 +36,7 @@ namespace Shadowsocks.Proxy
 
             public object AsyncState { get; set; }
 
-            public int BytesToRead;
+            public int BytesToRead { get; set; }
 
             public Exception ex { get; set; }
         }

--- a/shadowsocks-csharp/Proxy/Socks5Proxy.cs
+++ b/shadowsocks-csharp/Proxy/Socks5Proxy.cs
@@ -34,7 +34,7 @@ namespace Shadowsocks.Proxy
 
             public object AsyncState { get; set; }
 
-            public int BytesToRead;
+            public int BytesToRead { get; set; }
 
             public Exception ex { get; set; }
         }

--- a/shadowsocks-csharp/StringEx.cs
+++ b/shadowsocks-csharp/StringEx.cs
@@ -69,12 +69,12 @@ static partial class StringEx
         fixed (char* low = value)
         {
             var end = low + value.Length;
-            for (var p = low; p < end; p++)
+            for (var p = low; p < end; ++p)
             {
                 var c = *p;
                 if (c < 'A' || c > 'Z')
                     continue;
-                *p = (char)(c + 0x20);
+                *p = c - 'A' + 'a';
             }
         }
         return value;
@@ -89,12 +89,12 @@ static partial class StringEx
         fixed (char* low = value)
         {
             var end = low + value.Length;
-            for (var p = low; p < end; p++)
+            for (var p = low; p < end; ++p)
             {
                 var c = *p;
                 if (c < 'a' || c > 'z')
                     continue;
-                *p = (char)(c - 0x20);
+                *p = c - 'a' + 'A';
             }
         }
         return value;
@@ -111,7 +111,7 @@ static partial class StringEx
             if (c < 'A' || c > 'Z')
                 sb.Append(c);
             else
-                sb.Append((char)(c + 0x20));
+                sb.Append(c - 'A' + 'a');
         }
         return sb.ToString();
     }
@@ -127,7 +127,7 @@ static partial class StringEx
             if (c < 'a' || c > 'z')
                 sb.Append(c);
             else
-                sb.Append((char)(c - 0x20));
+                sb.Append(c - 'a' + 'A');
         }
         return sb.ToString();
     }


### PR DESCRIPTION
1. 何必留 warning CS0649 警告这么久。{ get; set; } 应该是 C# 标配吧， 对于大写字母开头的属性。
2. 抛开编译器优化, 前置 ++p 比 后置 p++ 少用一个寄存器性能更好. 当然对于现代编译器没有区别.  
    但你都 unsafe pointer 了不如彻底一点 ++p
3. (char)(c + 0x20) ：0x20 = 32 = 'a' - 'A' 这个 0x20 就是魔法数字呀。利用 ‘a’ 和 ‘A’ ASCII 编码
    距离差处理更通用，消除魔法数字，能让人容易理解。（当然底层库走映射表实现性能最好）
4. ‘a’ - ‘A’ 还能消除 （char）这种一点都不 C# 的强转 
： ）欢迎交流 - （C# 不太会望请打脸 ~）