### PR TITLE
When pluginOpts not exist, replace SIP003 variable in pluginArgs.

### DIFF
--- a/shadowsocks-csharp/Controller/Service/Sip003Plugin.cs
+++ b/shadowsocks-csharp/Controller/Service/Sip003Plugin.cs
@@ -50,6 +50,12 @@ namespace Shadowsocks.Controller.Service
 
             var appPath = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().GetName().CodeBase).LocalPath);
 
+            if (string.IsNullOrWhiteSpace(pluginOpts))
+            {
+                pluginArgs = pluginArgs.Replace("%SS_REMOTE_HOST%", serverAddress);
+                pluginArgs = pluginArgs.Replace("%SS_REMOTE_PORT%", serverPort.ToString());
+            }
+
             _pluginProcess = new Process
             {
                 StartInfo = new ProcessStartInfo
@@ -90,6 +96,12 @@ namespace Shadowsocks.Controller.Service
                 var localPort = GetNextFreeTcpPort();
                 LocalEndPoint = new IPEndPoint(IPAddress.Loopback, localPort);
 
+                // ["SS_PLUGIN_OPTIONS"] = pluginOpts
+                if (string.IsNullOrWhiteSpace(_pluginProcess.StartInfo.Environment["SS_PLUGIN_OPTIONS"]))
+                {
+                    _pluginProcess.StartInfo.Arguments = _pluginProcess.StartInfo.Arguments.Replace("%SS_LOCAL_HOST%", LocalEndPoint.Address.ToString());
+                    _pluginProcess.StartInfo.Arguments = _pluginProcess.StartInfo.Arguments.Replace("%SS_LOCAL_PORT%", LocalEndPoint.Port.ToString());
+                }
                 _pluginProcess.StartInfo.Environment["SS_LOCAL_HOST"] = LocalEndPoint.Address.ToString();
                 _pluginProcess.StartInfo.Environment["SS_LOCAL_PORT"] = LocalEndPoint.Port.ToString();
                 _pluginProcess.Start();


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [ ] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.


Work around for plugins which not support SIP003. When no pluginOpts used, replace %SS_REMOTE_HOST% .etc in pluginArgs to real value. So we can use something like `-l %SS_LOCAL_HOST%:%SS_LOCAL_PORT% -r %SS_REMOTE_HOST%:%SS_REMOTE_HOST%` as pluginArgs. 

See #1969 