### PR TITLE
Fix #1969 #1818

### DIFF
--- a/shadowsocks-csharp/Controller/Service/Sip003Plugin.cs
+++ b/shadowsocks-csharp/Controller/Service/Sip003Plugin.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
@@ -92,12 +93,28 @@ namespace Shadowsocks.Controller.Service
 
                 _pluginProcess.StartInfo.Environment["SS_LOCAL_HOST"] = LocalEndPoint.Address.ToString();
                 _pluginProcess.StartInfo.Environment["SS_LOCAL_PORT"] = LocalEndPoint.Port.ToString();
+                _pluginProcess.StartInfo.Arguments = ExpandEnvironmentVariables(_pluginProcess.StartInfo.Arguments, _pluginProcess.StartInfo.EnvironmentVariables);
                 _pluginProcess.Start();
                 _pluginJob.AddProcess(_pluginProcess.Handle);
                 _started = true;
             }
 
             return true;
+        }
+
+        public string ExpandEnvironmentVariables(string name, StringDictionary environmentVariables = null)
+        {
+            // Expand the environment variables from the new process itself
+            if (environmentVariables != null)
+            {
+                foreach(string key in environmentVariables.Keys)
+                {
+                    name = name.Replace($"%{key}%", environmentVariables[key], StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            // Also expand the environment variables from current main process (system)
+            name = Environment.ExpandEnvironmentVariables(name);
+            return name;
         }
 
         static int GetNextFreeTcpPort()


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

---

### Description

Cause: process's additional environment variables are not expanded correctly when processing ProcessStartInfo.Arguments.

Innovated by studentmain (StudentEx <scncgz@gmail.com>)