### PR TITLE
Improve sysproxy exception handling

### DIFF
--- a/shadowsocks-csharp/Controller/Logging.cs
+++ b/shadowsocks-csharp/Controller/Logging.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Diagnostics;
 using System.Text;
 using Shadowsocks.Util;
+using Shadowsocks.Util.SystemProxy;
 
 namespace Shadowsocks.Controller
 {
@@ -145,6 +146,24 @@ namespace Shadowsocks.Controller
                 {
                     Info(e);
                 }
+            }
+            else if (e is ProxyException)
+            {
+                var ex = (ProxyException)e;
+                switch (ex.Type)
+                {
+                    case ProxyExceptionType.FailToRun:
+                    case ProxyExceptionType.QueryReturnMalformed:
+                    case ProxyExceptionType.SysproxyExitError:
+                        Error($"sysproxy - {ex.Type.ToString()}:{ex.Message}");
+                        break;
+                    case ProxyExceptionType.QueryReturnEmpty:
+                    case ProxyExceptionType.Unspecific:
+                        Error($"sysproxy - {ex.Type.ToString()}");
+                        break;
+                }
+
+
             }
             else
             {

--- a/shadowsocks-csharp/Controller/System/SystemProxy.cs
+++ b/shadowsocks-csharp/Controller/System/SystemProxy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows.Forms;
 using Shadowsocks.Model;
 using Shadowsocks.Util.SystemProxy;
 
@@ -6,6 +7,8 @@ namespace Shadowsocks.Controller
 {
     public static class SystemProxy
     {
+        private static bool failed = false;
+
         private static string GetTimestamp(DateTime value)
         {
             return value.ToString("yyyyMMddHHmmssfff");
@@ -13,6 +16,7 @@ namespace Shadowsocks.Controller
 
         public static void Update(Configuration config, bool forceDisable, PACServer pacSrv)
         {
+            if (failed) return;
             bool global = config.global;
             bool enabled = config.enabled;
 
@@ -51,6 +55,19 @@ namespace Shadowsocks.Controller
             catch (ProxyException ex)
             {
                 Logging.LogUsefulException(ex);
+                switch (ex.Type)
+                {
+                    case ProxyExceptionType.FailToRun:
+                        MessageBox.Show(I18N.GetString("Error when running sysproxy, check your proxy config"), I18N.GetString("Shadowsocks"));
+                        break;
+                    case ProxyExceptionType.QueryReturnMalformed:
+                    case ProxyExceptionType.QueryReturnEmpty:
+                        MessageBox.Show(I18N.GetString("Can't query proxy config, check your proxy config"), I18N.GetString("Shadowsocks"));
+                        break;
+                    case ProxyExceptionType.SysproxyExitError:
+                        MessageBox.Show(I18N.GetString("Sysproxy return a error:") + ex.Message, I18N.GetString("Shadowsocks"));
+                        break;
+                }
             }
         }
     }

--- a/shadowsocks-csharp/Data/ja.txt
+++ b/shadowsocks-csharp/Data/ja.txt
@@ -149,6 +149,5 @@ Register hotkey failed=ホットキーの登錄に失敗しました。
 Cannot parse hotkey: {0}=ホットキーを解析できません: {0}
 Timeout is invalid, it should not exceed {0}=タイムアウト値が無効です。{0} 以下の値を指定して下さい。
 
-Error when running sysproxy, check your proxy config=执行sysproxy时发生错误，请检查你的系统代理设置
-Can't query proxy config, check your proxy config=无法解析代理配置，请检查你的系统代理设置
-Sysproxy return a error:=sysproxy报告了一个错误：
+Error occured when process proxy setting, do you want reset current setting and retry?=处理代理设置时发生错误，是否重置当前代理设置并重试？
+Unrecoverable proxy setting error occured, see log for detail=发生不可恢复的代理设置错误，查看日志以取得详情

--- a/shadowsocks-csharp/Data/ja.txt
+++ b/shadowsocks-csharp/Data/ja.txt
@@ -148,6 +148,3 @@ Proxy handshake failed=プロキシ ハンドシェイクに失敗しました�
 Register hotkey failed=ホットキーの登錄に失敗しました。
 Cannot parse hotkey: {0}=ホットキーを解析できません: {0}
 Timeout is invalid, it should not exceed {0}=タイムアウト値が無効です。{0} 以下の値を指定して下さい。
-
-Error occured when process proxy setting, do you want reset current setting and retry?=处理代理设置时发生错误，是否重置当前代理设置并重试？
-Unrecoverable proxy setting error occured, see log for detail=发生不可恢复的代理设置错误，查看日志以取得详情

--- a/shadowsocks-csharp/Data/ja.txt
+++ b/shadowsocks-csharp/Data/ja.txt
@@ -148,3 +148,7 @@ Proxy handshake failed=プロキシ ハンドシェイクに失敗しました�
 Register hotkey failed=ホットキーの登錄に失敗しました。
 Cannot parse hotkey: {0}=ホットキーを解析できません: {0}
 Timeout is invalid, it should not exceed {0}=タイムアウト値が無効です。{0} 以下の値を指定して下さい。
+
+Error when running sysproxy, check your proxy config=执行sysproxy时发生错误，请检查你的系统代理设置
+Can't query proxy config, check your proxy config=无法解析代理配置，请检查你的系统代理设置
+Sysproxy return a error:=sysproxy报告了一个错误：

--- a/shadowsocks-csharp/Data/zh_CN.txt
+++ b/shadowsocks-csharp/Data/zh_CN.txt
@@ -148,3 +148,7 @@ Proxy handshake failed=代理握手失败
 Register hotkey failed=注册快捷键失败
 Cannot parse hotkey: {0}=解析快捷键失败: {0}
 Timeout is invalid, it should not exceed {0}=超时无效，不应超过 {0}
+
+Error when running sysproxy, check your proxy config=执行sysproxy时发生错误，请检查你的系统代理设置
+Can't query proxy config, check your proxy config=无法解析代理配置，请检查你的系统代理设置
+Sysproxy return a error:=sysproxy报告了一个错误：

--- a/shadowsocks-csharp/Data/zh_CN.txt
+++ b/shadowsocks-csharp/Data/zh_CN.txt
@@ -149,6 +149,5 @@ Register hotkey failed=注册快捷键失败
 Cannot parse hotkey: {0}=解析快捷键失败: {0}
 Timeout is invalid, it should not exceed {0}=超时无效，不应超过 {0}
 
-Error when running sysproxy, check your proxy config=执行sysproxy时发生错误，请检查你的系统代理设置
-Can't query proxy config, check your proxy config=无法解析代理配置，请检查你的系统代理设置
-Sysproxy return a error:=sysproxy报告了一个错误：
+Error occured when process proxy setting, do you want reset current setting and retry?=处理代理设置时发生错误，是否重置当前代理设置并重试？
+Unrecoverable proxy setting error occured, see log for detail=发生不可恢复的代理设置错误，查看日志以取得详情

--- a/shadowsocks-csharp/Data/zh_TW.txt
+++ b/shadowsocks-csharp/Data/zh_TW.txt
@@ -148,3 +148,7 @@ Proxy handshake failed=Proxy 交握失敗
 Register hotkey failed=註冊快速鍵失敗
 Cannot parse hotkey: {0}=剖析快速鍵失敗: {0}
 Timeout is invalid, it should not exceed {0}=逾時無效，不應超過 {0}
+
+Error when running sysproxy, check your proxy config=执行sysproxy时发生错误，请检查你的系统代理设置
+Can't query proxy config, check your proxy config=无法解析代理配置，请检查你的系统代理设置
+Sysproxy return a error:=sysproxy报告了一个错误：

--- a/shadowsocks-csharp/Data/zh_TW.txt
+++ b/shadowsocks-csharp/Data/zh_TW.txt
@@ -149,6 +149,5 @@ Register hotkey failed=註冊快速鍵失敗
 Cannot parse hotkey: {0}=剖析快速鍵失敗: {0}
 Timeout is invalid, it should not exceed {0}=逾時無效，不應超過 {0}
 
-Error when running sysproxy, check your proxy config=执行sysproxy时发生错误，请检查你的系统代理设置
-Can't query proxy config, check your proxy config=无法解析代理配置，请检查你的系统代理设置
-Sysproxy return a error:=sysproxy报告了一个错误：
+Error occured when process proxy setting, do you want reset current setting and retry?=处理代理设置时发生错误，是否重置当前代理设置并重试？
+Unrecoverable proxy setting error occured, see log for detail=发生不可恢复的代理设置错误，查看日志以取得详情

--- a/shadowsocks-csharp/Data/zh_TW.txt
+++ b/shadowsocks-csharp/Data/zh_TW.txt
@@ -148,6 +148,3 @@ Proxy handshake failed=Proxy 交握失敗
 Register hotkey failed=註冊快速鍵失敗
 Cannot parse hotkey: {0}=剖析快速鍵失敗: {0}
 Timeout is invalid, it should not exceed {0}=逾時無效，不應超過 {0}
-
-Error occured when process proxy setting, do you want reset current setting and retry?=处理代理设置时发生错误，是否重置当前代理设置并重试？
-Unrecoverable proxy setting error occured, see log for detail=发生不可恢复的代理设置错误，查看日志以取得详情

--- a/shadowsocks-csharp/Util/SystemProxy/ProxyException.cs
+++ b/shadowsocks-csharp/Util/SystemProxy/ProxyException.cs
@@ -7,8 +7,20 @@ using System.Threading.Tasks;
 
 namespace Shadowsocks.Util.SystemProxy
 {
+    enum ProxyExceptionType
+    {
+        Unspecific,
+        FailToRun,
+        QueryReturnEmpty,
+        SysproxyExitError,
+        QueryReturnMalformed
+    }
+
     class ProxyException : Exception
     {
+        // provide more specific information about exception
+        public ProxyExceptionType Type { get; }
+
         public ProxyException()
         {
         }
@@ -23,6 +35,25 @@ namespace Shadowsocks.Util.SystemProxy
 
         protected ProxyException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
+        }
+        public ProxyException(ProxyExceptionType type)
+        {
+            this.Type = type;
+        }
+
+        public ProxyException(ProxyExceptionType type, string message) : base(message)
+        {
+            this.Type = type;
+        }
+
+        public ProxyException(ProxyExceptionType type, string message, Exception innerException) : base(message, innerException)
+        {
+            this.Type = type;
+        }
+
+        protected ProxyException(ProxyExceptionType type, SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            this.Type = type;
         }
     }
 }

--- a/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
+++ b/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
@@ -193,6 +193,16 @@ namespace Shadowsocks.Util.SystemProxy
         private static void ParseQueryStr(string str)
         {
             string[] userSettingsArr = str.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+
+            // sometimes sysproxy output in utf16le instead of ascii
+            // manually translate it
+            if (userSettingsArr.Length == 1)
+            {
+                byte[] strByte = Encoding.ASCII.GetBytes(str);
+                str = Encoding.Unicode.GetString(strByte);
+                userSettingsArr = str.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            }
+
             _userSettings.Flags = userSettingsArr[0];
 
             // handle output from WinINET

--- a/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
+++ b/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
@@ -82,6 +82,26 @@ namespace Shadowsocks.Util.SystemProxy
             ExecSysproxy(arguments);
         }
 
+
+        // set system proxy to 1 (null) (null) (null)
+        public static bool ResetIEProxy()
+        {
+            try
+            {
+            // clear user-wininet.json
+            _userSettings = new SysproxyConfig();
+            Save();
+            // clear system setting
+            ExecSysproxy("set 1 - - -");
+            }
+            catch (Exception e)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         private static void ExecSysproxy(string arguments)
         {
             // using event to avoid hanging when redirect standard output/error
@@ -146,8 +166,6 @@ namespace Shadowsocks.Util.SystemProxy
                         // log the arguements
                         throw new ProxyException(ProxyExceptionType.FailToRun, process.StartInfo.Arguments, e);
                     }
-
-
                     var stderr = error.ToString();
                     var stdout = output.ToString();
 

--- a/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
+++ b/shadowsocks-csharp/Util/SystemProxy/Sysproxy.cs
@@ -149,8 +149,10 @@ namespace Shadowsocks.Util.SystemProxy
                         throw new ProxyException(stderr);
                     }
 
-                    if (arguments == "query") {
-                        if (stdout.IsNullOrWhiteSpace() || stdout.IsNullOrEmpty()) {
+                    if (arguments == "query")
+                    {
+                        if (stdout.IsNullOrWhiteSpace() || stdout.IsNullOrEmpty())
+                        {
                             // we cannot get user settings
                             throw new ProxyException("failed to query wininet settings");
                         }
@@ -183,9 +185,13 @@ namespace Shadowsocks.Util.SystemProxy
             {
                 string configContent = File.ReadAllText(Utils.GetTempPath(_userWininetConfigFile));
                 _userSettings = JsonConvert.DeserializeObject<SysproxyConfig>(configContent);
-            } catch(Exception) {
+            }
+            catch (Exception)
+            {
                 // Suppress all exceptions. finally block will initialize new user config settings.
-            } finally {
+            }
+            finally
+            {
                 if (_userSettings == null) _userSettings = new SysproxyConfig();
             }
         }
@@ -196,13 +202,18 @@ namespace Shadowsocks.Util.SystemProxy
 
             // sometimes sysproxy output in utf16le instead of ascii
             // manually translate it
-            if (userSettingsArr.Length == 1)
+            if (userSettingsArr.Length != 4)
             {
                 byte[] strByte = Encoding.ASCII.GetBytes(str);
                 str = Encoding.Unicode.GetString(strByte);
                 userSettingsArr = str.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+                // still fail, throw exception with string hexdump
+                if (userSettingsArr.Length != 4)
+                {
+                    throw new ProxyException("Unexpected sysproxy output:" + BitConverter.ToString(strByte));
+                }
             }
-
+            
             _userSettings.Flags = userSettingsArr[0];
 
             // handle output from WinINET


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

#1487
https://github.com/shadowsocks/shadowsocks-windows/issues/1991#issuecomment-422240535
#2013

- Sysproxy.exe sometimes output in UTF16LE, cause parse fail. Manually convert it and retry.
- when fail, log information (`sysproxy` args, `sysproxy query` return string), then clear proxy setting and retry if requested.
