### PR TITLE
支持配置文件存放在单独的目录

### DIFF
--- a/shadowsocks-csharp/Model/ConfigPath.cs
+++ b/shadowsocks-csharp/Model/ConfigPath.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Shadowsocks.Model
+{
+    class ConfigPath
+    {
+        const string PATH_FILE = "path";
+
+        public static string Load()
+        {
+            try
+            {
+                string path = File.ReadAllText(PATH_FILE);
+                DirectoryInfo di;
+                if (Directory.Exists(path))
+                {
+                    di = new DirectoryInfo(path);
+                }
+                else
+                {
+                    di = Directory.CreateDirectory(path);
+                }
+                return di.FullName + "\\";
+            }
+            catch
+            {
+                return "";
+            }
+        }
+    }
+}

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -56,7 +56,7 @@ namespace Shadowsocks.Model
         {
             try
             {
-                string configContent = File.ReadAllText(CONFIG_FILE);
+                string configContent = File.ReadAllText(ConfigPath.Load() + CONFIG_FILE);
                 Configuration config = JsonConvert.DeserializeObject<Configuration>(configContent);
                 config.isDefault = false;
 
@@ -112,7 +112,7 @@ namespace Shadowsocks.Model
             config.isDefault = false;
             try
             {
-                using (StreamWriter sw = new StreamWriter(File.Open(CONFIG_FILE, FileMode.Create)))
+                using (StreamWriter sw = new StreamWriter(File.Open(ConfigPath.Load() + CONFIG_FILE, FileMode.Create)))
                 {
                     string jsonString = JsonConvert.SerializeObject(config, Formatting.Indented);
                     sw.Write(jsonString);

--- a/shadowsocks-csharp/Model/StatisticsStrategyConfiguration.cs
+++ b/shadowsocks-csharp/Model/StatisticsStrategyConfiguration.cs
@@ -27,7 +27,7 @@ namespace Shadowsocks.Model
         {
             try
             {
-                var content = File.ReadAllText(ConfigFile);
+                var content = File.ReadAllText(ConfigPath.Load() + ConfigFile);
                 var configuration = JsonConvert.DeserializeObject<StatisticsStrategyConfiguration>(content);
                 return configuration;
             }
@@ -49,7 +49,7 @@ namespace Shadowsocks.Model
             try
             {
                 var content = JsonConvert.SerializeObject(configuration, Formatting.Indented);
-                File.WriteAllText(ConfigFile, content);
+                File.WriteAllText(ConfigPath.Load() + ConfigFile, content);
             }
             catch (Exception e)
             {

--- a/shadowsocks-csharp/shadowsocks-csharp.csproj
+++ b/shadowsocks-csharp/shadowsocks-csharp.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Encryption\Stream\StreamMbedTLSEncryptor.cs" />
     <Compile Include="Encryption\Stream\StreamOpenSSLEncryptor.cs" />
     <Compile Include="Encryption\Stream\StreamSodiumEncryptor.cs" />
+    <Compile Include="Model\ConfigPath.cs" />
     <Compile Include="Model\HotKeyConfig.cs" />
     <Compile Include="Model\ProxyConfig.cs" />
     <Compile Include="Model\SysproxyConfig.cs" />


### PR DESCRIPTION
可在程序目录创建一个文件 path，内容为一个路径，这样就会从这个目录读取配置。
方便使用各种同步盘同步配置