### PR TITLE
fix #1979 - pac-secret

### DIFF
--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -499,6 +499,7 @@ namespace Shadowsocks.Controller
             {
                 _pacServer = new PACServer();
                 _pacServer.PACFileChanged += pacServer_PACFileChanged;
+                _pacServer.PACSecretFileChanged += pacServer_PACSecretFileChanged;
                 _pacServer.UserRuleFileChanged += pacServer_UserRuleFileChanged;
             }
             _pacServer.UpdateConfiguration(_config);
@@ -587,6 +588,12 @@ namespace Shadowsocks.Controller
         }
 
         private void pacServer_PACFileChanged(object sender, EventArgs e)
+        {
+            UpdateSystemProxy();
+        }
+
+
+        private void pacServer_PACSecretFileChanged(object sender, EventArgs e)
         {
             UpdateSystemProxy();
         }

--- a/shadowsocks-csharp/Controller/System/SystemProxy.cs
+++ b/shadowsocks-csharp/Controller/System/SystemProxy.cs
@@ -39,6 +39,7 @@ namespace Shadowsocks.Controller
                         }
                         else
                         {
+                            pacSrv.UpdateConfiguration(config);
                             pacUrl = pacSrv.PacUrl;
                         }
                         Sysproxy.SetIEProxy(true, false, null, pacUrl);


### PR DESCRIPTION
修复 #1979 

修复了常规情形下出现大量`pacjsworker.exe`进程的bug。代码可以正常编译，程序经过测试并和官方版本进行了对比，达到预期效果。

新代码在常规使用时不会出现多个pacjsworker进程的现象。如果使用中需要改变配置，能对以下情形做到立即生效，无需重启程序或者浏览器：

1. 修改端口后，生成新的PAC地址，立即生效；
2. 启用或禁用pac文件保护后生成新的PAC地址，立即生效；
3. 手工修改pac.txt/user-rule.txt，生成新的PAC地址，立即生效；
4. 手工修改pac-secret文件，立即生效；

目前官方版本对第二点和第三点不是立即生效，需要重启浏览器。本次pull对其进行功能增强，文件修改后无需重启浏览器。

问题根源还是一句话：一个PAC地址会拉起一个pacjsworker.exe进程，不管程序设置还是手动在IE里设置！
