### PR TITLE
Marked ApplicationRestartFlags with Flags attribute

### DIFF
--- a/shadowsocks-csharp/Controller/System/AutoStartup.cs
+++ b/shadowsocks-csharp/Controller/System/AutoStartup.cs
@@ -115,6 +115,7 @@ namespace Shadowsocks.Controller
         [DllImport("kernel32.dll", SetLastError = true)]
         static extern int UnregisterApplicationRestart();
 
+        [Flags]
         enum ApplicationRestartFlags
         {
             RESTART_NO_CRASH = 1,
@@ -137,7 +138,7 @@ namespace Shadowsocks.Controller
                 string cmdline = string.Join(" ", args);
                 // first parameter is process command line parameter
                 // needn't include the name of the executable in the command line
-                RegisterApplicationRestart(cmdline, (int)ApplicationRestartFlags.RESTART_NO_CRASH | (int)ApplicationRestartFlags.RESTART_NO_HANG);
+                RegisterApplicationRestart(cmdline, (int)(ApplicationRestartFlags.RESTART_NO_CRASH | ApplicationRestartFlags.RESTART_NO_HANG));
                 Logging.Debug("Register restart after system reboot, command line:" + cmdline);
             }
             // requested unregister, which has no side effect

--- a/shadowsocks-csharp/Controller/System/AutoStartup.cs
+++ b/shadowsocks-csharp/Controller/System/AutoStartup.cs
@@ -118,6 +118,7 @@ namespace Shadowsocks.Controller
         [Flags]
         enum ApplicationRestartFlags
         {
+            RESTART_ALWAYS = 0,
             RESTART_NO_CRASH = 1,
             RESTART_NO_HANG = 2,
             RESTART_NO_PATCH = 4,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information
Marked ApplicationRestartFlags with Flags attribute because enum are powered of 2. The nature of this enum is a set of binary flags.