### PR TITLE
add "basic access authentication" support for http proxy

### DIFF
--- a/shadowsocks-csharp/Controller/Service/TCPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/TCPRelay.cs
@@ -689,9 +689,16 @@ namespace Shadowsocks.Controller
                 connectTimer.Server = server;
 
                 _destConnected = false;
+
+                NetworkCredential auth = null;
+                if (_config.proxy.useAuth)
+                {
+                    auth = new NetworkCredential(_config.proxy.authUser, _config.proxy.authPwd);
+                }
+
                 // Connect to the remote endpoint.
                 remote.BeginConnectDest(destEndPoint, ConnectCallback,
-                    new AsyncSession<ServerTimer>(session, connectTimer));
+                    new AsyncSession<ServerTimer>(session, connectTimer), auth);
             }
             catch (ArgumentException)
             {

--- a/shadowsocks-csharp/Data/ja.txt
+++ b/shadowsocks-csharp/Data/ja.txt
@@ -73,6 +73,9 @@ Proxy Type=プロキシの種類
 Proxy Addr=プロキシアドレス
 Proxy Port=プロキシポート
 If server has a plugin, proxy will not be used=サーバーにプラグインがある場合、プロキシは利用されません
+Use Auth=認証を利用する
+Auth User=認証ユーザ
+Auth Pwd=認証パスワード
 
 # Log Form
 
@@ -148,3 +151,5 @@ Proxy handshake failed=プロキシ ハンドシェイクに失敗しました�
 Register hotkey failed=ホットキーの登錄に失敗しました。
 Cannot parse hotkey: {0}=ホットキーを解析できません: {0}
 Timeout is invalid, it should not exceed {0}=タイムアウト値が無効です。{0} 以下の値を指定して下さい。
+Auth user can not be blank=認証ユーザが指定されていません。
+Auth pwd can not be blank=認証パスワードが指定されていません。

--- a/shadowsocks-csharp/Data/zh_CN.txt
+++ b/shadowsocks-csharp/Data/zh_CN.txt
@@ -74,6 +74,9 @@ Proxy Type=代理类型
 Proxy Addr=代理地址
 Proxy Port=代理端口
 If server has a plugin, proxy will not be used=若服务器含有插件，代理将不被使用
+Use Auth=使用认证
+Auth User=认证用户
+Auth Pwd=认证密码
 
 # Log Form
 
@@ -152,3 +155,5 @@ Timeout is invalid, it should not exceed {0}=超时无效，不应超过 {0}
 
 Error occured when process proxy setting, do you want reset current setting and retry?=处理代理设置时发生错误，是否重置当前代理设置并重试？
 Unrecoverable proxy setting error occured, see log for detail=发生不可恢复的代理设置错误，查看日志以取得详情
+Auth user can not be blank=认证用户不能为空
+Auth pwd can not be blank=认证密码不能为空

--- a/shadowsocks-csharp/Data/zh_TW.txt
+++ b/shadowsocks-csharp/Data/zh_TW.txt
@@ -73,6 +73,9 @@ Proxy Type=Proxy 類型
 Proxy Addr=Proxy 位址
 Proxy Port=Proxy 連接埠
 If server has a plugin, proxy will not be used=若伺服器含有外掛程式，Proxy 將不被使用
+Use Auth=使用認證
+Auth User=認證用戶
+Auth Pwd=認證口令
 
 # Log Form
 
@@ -148,3 +151,5 @@ Proxy handshake failed=Proxy 交握失敗
 Register hotkey failed=註冊快速鍵失敗
 Cannot parse hotkey: {0}=剖析快速鍵失敗: {0}
 Timeout is invalid, it should not exceed {0}=逾時無效，不應超過 {0}
+Auth user can not be blank=認證用戶不能為空
+Auth pwd can not be blank=認證口令不能為空

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -167,5 +167,17 @@ namespace Shadowsocks.Model
                 throw new ArgumentException(
                     I18N.GetString("Timeout is invalid, it should not exceed {0}", maxTimeout));
         }
+
+        public static void CheckProxyAuthUser(string user)
+        {
+            if (user.IsNullOrEmpty())
+                throw new ArgumentException(I18N.GetString("Auth user can not be blank"));
+        }
+
+        public static void CheckProxyAuthPwd(string pwd)
+        {
+            if (pwd.IsNullOrEmpty())
+                throw new ArgumentException(I18N.GetString("Auth pwd can not be blank"));
+        }
     }
 }

--- a/shadowsocks-csharp/Model/ProxyConfig.cs
+++ b/shadowsocks-csharp/Model/ProxyConfig.cs
@@ -16,6 +16,9 @@ namespace Shadowsocks.Model
         public string proxyServer;
         public int proxyPort;
         public int proxyTimeout;
+        public bool useAuth;
+        public string authUser;
+        public string authPwd;
 
         public ProxyConfig()
         {
@@ -24,6 +27,9 @@ namespace Shadowsocks.Model
             proxyServer = "";
             proxyPort = 0;
             proxyTimeout = DefaultProxyTimeoutSec;
+            useAuth = false;
+            authUser = "";
+            authPwd = "";
         }
 
         public void CheckConfig()

--- a/shadowsocks-csharp/Proxy/DirectConnect.cs
+++ b/shadowsocks-csharp/Proxy/DirectConnect.cs
@@ -51,7 +51,7 @@ namespace Shadowsocks.Proxy
             // do nothing
         }
 
-        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state)
+        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state, NetworkCredential auth = null)
         {
             DestEndPoint = destEndPoint;
 

--- a/shadowsocks-csharp/Proxy/HttpProxy.cs
+++ b/shadowsocks-csharp/Proxy/HttpProxy.cs
@@ -68,12 +68,20 @@ namespace Shadowsocks.Proxy
             "Host: {0}" + HTTP_CRLF +
             "Proxy-Connection: keep-alive" + HTTP_CRLF +
             "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36" + HTTP_CRLF +
+            "{1}" +         // Proxy-Authorization if any
             "" + HTTP_CRLF; // End with an empty line
+        private const string PROXY_AUTH_TEMPLATE = "Proxy-Authorization: Basic {0}" + HTTP_CRLF;
 
-        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state)
+        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state, NetworkCredential auth = null)
         {
             DestEndPoint = destEndPoint;
-            string request = string.Format(HTTP_CONNECT_TEMPLATE, destEndPoint);
+            String authInfo = "";
+            if (auth != null)
+            {
+                string authKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(auth.UserName + ":" + auth.Password));
+                authInfo = string.Format(PROXY_AUTH_TEMPLATE, authKey);
+            }
+            string request = string.Format(HTTP_CONNECT_TEMPLATE, destEndPoint, authInfo);
 
             var b = Encoding.UTF8.GetBytes(request);
 

--- a/shadowsocks-csharp/Proxy/IProxy.cs
+++ b/shadowsocks-csharp/Proxy/IProxy.cs
@@ -17,7 +17,7 @@ namespace Shadowsocks.Proxy
 
         void EndConnectProxy(IAsyncResult asyncResult);
 
-        void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state);
+        void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state, NetworkCredential auth = null);
 
         void EndConnectDest(IAsyncResult asyncResult);
 

--- a/shadowsocks-csharp/Proxy/Socks5Proxy.cs
+++ b/shadowsocks-csharp/Proxy/Socks5Proxy.cs
@@ -69,8 +69,9 @@ namespace Shadowsocks.Proxy
             }
         }
 
-        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state)
+        public void BeginConnectDest(EndPoint destEndPoint, AsyncCallback callback, object state, NetworkCredential auth = null)
         {
+            // TODO: support SOCKS5 auth
             DestEndPoint = destEndPoint;
 
             byte[] request = null;

--- a/shadowsocks-csharp/View/ProxyForm.Designer.cs
+++ b/shadowsocks-csharp/View/ProxyForm.Designer.cs
@@ -42,6 +42,11 @@
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.ProxyNotificationLabel = new System.Windows.Forms.Label();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.AuthUserLabel = new System.Windows.Forms.Label();
+            this.AuthPwdLabel = new System.Windows.Forms.Label();
+            this.UseAuthCheckBox = new System.Windows.Forms.CheckBox();
+            this.AuthUserTextBox = new System.Windows.Forms.TextBox();
+            this.AuthPwdTextBox = new System.Windows.Forms.TextBox();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
@@ -72,9 +77,10 @@
             // 
             // UseProxyCheckBox
             // 
+            this.UseProxyCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.UseProxyCheckBox.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.UseProxyCheckBox, 2);
-            this.UseProxyCheckBox.Location = new System.Drawing.Point(3, 3);
+            this.UseProxyCheckBox.Location = new System.Drawing.Point(3, 6);
             this.UseProxyCheckBox.Name = "UseProxyCheckBox";
             this.UseProxyCheckBox.Size = new System.Drawing.Size(78, 16);
             this.UseProxyCheckBox.TabIndex = 0;
@@ -86,7 +92,7 @@
             // 
             this.ProxyAddrLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.ProxyAddrLabel.AutoSize = true;
-            this.ProxyAddrLabel.Location = new System.Drawing.Point(3, 71);
+            this.ProxyAddrLabel.Location = new System.Drawing.Point(3, 64);
             this.ProxyAddrLabel.Name = "ProxyAddrLabel";
             this.ProxyAddrLabel.Size = new System.Drawing.Size(65, 12);
             this.ProxyAddrLabel.TabIndex = 0;
@@ -95,10 +101,10 @@
             // ProxyServerTextBox
             // 
             this.ProxyServerTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.ProxyServerTextBox.Location = new System.Drawing.Point(74, 67);
+            this.ProxyServerTextBox.Location = new System.Drawing.Point(74, 59);
             this.ProxyServerTextBox.MaxLength = 512;
             this.ProxyServerTextBox.Name = "ProxyServerTextBox";
-            this.ProxyServerTextBox.Size = new System.Drawing.Size(142, 21);
+            this.ProxyServerTextBox.Size = new System.Drawing.Size(138, 21);
             this.ProxyServerTextBox.TabIndex = 1;
             this.ProxyServerTextBox.WordWrap = false;
             // 
@@ -106,7 +112,7 @@
             // 
             this.ProxyPortLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.ProxyPortLabel.AutoSize = true;
-            this.ProxyPortLabel.Location = new System.Drawing.Point(222, 71);
+            this.ProxyPortLabel.Location = new System.Drawing.Point(218, 64);
             this.ProxyPortLabel.Name = "ProxyPortLabel";
             this.ProxyPortLabel.Size = new System.Drawing.Size(77, 12);
             this.ProxyPortLabel.TabIndex = 2;
@@ -115,10 +121,10 @@
             // ProxyPortTextBox
             // 
             this.ProxyPortTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.ProxyPortTextBox.Location = new System.Drawing.Point(305, 67);
+            this.ProxyPortTextBox.Location = new System.Drawing.Point(301, 59);
             this.ProxyPortTextBox.MaxLength = 10;
             this.ProxyPortTextBox.Name = "ProxyPortTextBox";
-            this.ProxyPortTextBox.Size = new System.Drawing.Size(58, 21);
+            this.ProxyPortTextBox.Size = new System.Drawing.Size(91, 21);
             this.ProxyPortTextBox.TabIndex = 3;
             this.ProxyPortTextBox.WordWrap = false;
             // 
@@ -126,7 +132,7 @@
             // 
             this.ProxyTypeLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.ProxyTypeLabel.AutoSize = true;
-            this.ProxyTypeLabel.Location = new System.Drawing.Point(3, 40);
+            this.ProxyTypeLabel.Location = new System.Drawing.Point(3, 36);
             this.ProxyTypeLabel.Name = "ProxyTypeLabel";
             this.ProxyTypeLabel.Size = new System.Drawing.Size(65, 12);
             this.ProxyTypeLabel.TabIndex = 1;
@@ -140,25 +146,26 @@
             this.ProxyTypeComboBox.Items.AddRange(new object[] {
             "SOCKS5",
             "HTTP"});
-            this.ProxyTypeComboBox.Location = new System.Drawing.Point(74, 36);
+            this.ProxyTypeComboBox.Location = new System.Drawing.Point(74, 33);
             this.ProxyTypeComboBox.Margin = new System.Windows.Forms.Padding(3, 5, 3, 5);
             this.ProxyTypeComboBox.Name = "ProxyTypeComboBox";
-            this.ProxyTypeComboBox.Size = new System.Drawing.Size(142, 20);
+            this.ProxyTypeComboBox.Size = new System.Drawing.Size(138, 20);
             this.ProxyTypeComboBox.TabIndex = 2;
+            this.ProxyTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.ProxyTypeComboBox_SelectedIndexChanged);
             // 
             // ProxyTimeoutTextBox
             // 
             this.ProxyTimeoutTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.ProxyTimeoutTextBox.Location = new System.Drawing.Point(305, 36);
+            this.ProxyTimeoutTextBox.Location = new System.Drawing.Point(301, 31);
             this.ProxyTimeoutTextBox.Name = "ProxyTimeoutTextBox";
-            this.ProxyTimeoutTextBox.Size = new System.Drawing.Size(58, 21);
+            this.ProxyTimeoutTextBox.Size = new System.Drawing.Size(91, 21);
             this.ProxyTimeoutTextBox.TabIndex = 3;
             // 
             // ProxyTimeoutLabel
             // 
             this.ProxyTimeoutLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.ProxyTimeoutLabel.AutoSize = true;
-            this.ProxyTimeoutLabel.Location = new System.Drawing.Point(222, 40);
+            this.ProxyTimeoutLabel.Location = new System.Drawing.Point(218, 36);
             this.ProxyTimeoutLabel.Name = "ProxyTimeoutLabel";
             this.ProxyTimeoutLabel.Size = new System.Drawing.Size(77, 12);
             this.ProxyTimeoutLabel.TabIndex = 4;
@@ -169,9 +176,9 @@
             this.tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel1.ColumnCount = 4;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 70F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 60F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 30F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 40F));
             this.tableLayoutPanel1.Controls.Add(this.UseProxyCheckBox, 0, 0);
             this.tableLayoutPanel1.Controls.Add(this.ProxyTypeLabel, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.ProxyPortTextBox, 3, 2);
@@ -182,16 +189,23 @@
             this.tableLayoutPanel1.Controls.Add(this.ProxyServerTextBox, 1, 2);
             this.tableLayoutPanel1.Controls.Add(this.ProxyAddrLabel, 0, 2);
             this.tableLayoutPanel1.Controls.Add(this.ProxyNotificationLabel, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.AuthUserLabel, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.AuthPwdLabel, 2, 5);
+            this.tableLayoutPanel1.Controls.Add(this.UseAuthCheckBox, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.AuthUserTextBox, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.AuthPwdTextBox, 3, 5);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(15, 15);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 5;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 21.95122F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 21.95122F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 21.95122F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 34.14634F));
+            this.tableLayoutPanel1.RowCount = 7;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66713F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66713F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.66713F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.6662F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.6662F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 16.6662F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(366, 177);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(395, 204);
             this.tableLayoutPanel1.TabIndex = 14;
             // 
             // ProxyNotificationLabel
@@ -200,9 +214,9 @@
             this.ProxyNotificationLabel.AutoSize = true;
             this.tableLayoutPanel1.SetColumnSpan(this.ProxyNotificationLabel, 4);
             this.ProxyNotificationLabel.ForeColor = System.Drawing.Color.Red;
-            this.ProxyNotificationLabel.Location = new System.Drawing.Point(3, 111);
+            this.ProxyNotificationLabel.Location = new System.Drawing.Point(3, 92);
             this.ProxyNotificationLabel.Name = "ProxyNotificationLabel";
-            this.ProxyNotificationLabel.Size = new System.Drawing.Size(360, 12);
+            this.ProxyNotificationLabel.Size = new System.Drawing.Size(389, 12);
             this.ProxyNotificationLabel.TabIndex = 5;
             this.ProxyNotificationLabel.Text = "If server has a plugin, proxy will not be used";
             // 
@@ -215,10 +229,60 @@
             this.flowLayoutPanel1.Controls.Add(this.OKButton);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Right;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(204, 145);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(233, 171);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(159, 29);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(159, 30);
             this.flowLayoutPanel1.TabIndex = 6;
+            // 
+            // AuthUserLabel
+            // 
+            this.AuthUserLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.AuthUserLabel.AutoSize = true;
+            this.AuthUserLabel.Location = new System.Drawing.Point(3, 148);
+            this.AuthUserLabel.Name = "AuthUserLabel";
+            this.AuthUserLabel.Size = new System.Drawing.Size(65, 12);
+            this.AuthUserLabel.TabIndex = 7;
+            this.AuthUserLabel.Text = "User Name";
+            // 
+            // AuthPwdLabel
+            // 
+            this.AuthPwdLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.AuthPwdLabel.AutoSize = true;
+            this.AuthPwdLabel.Location = new System.Drawing.Point(218, 148);
+            this.AuthPwdLabel.Name = "AuthPwdLabel";
+            this.AuthPwdLabel.Size = new System.Drawing.Size(77, 12);
+            this.AuthPwdLabel.TabIndex = 8;
+            this.AuthPwdLabel.Text = "Password";
+            // 
+            // UseAuthCheckBox
+            // 
+            this.UseAuthCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.UseAuthCheckBox.AutoSize = true;
+            this.tableLayoutPanel1.SetColumnSpan(this.UseAuthCheckBox, 2);
+            this.UseAuthCheckBox.Location = new System.Drawing.Point(3, 118);
+            this.UseAuthCheckBox.Name = "UseAuthCheckBox";
+            this.UseAuthCheckBox.Size = new System.Drawing.Size(72, 16);
+            this.UseAuthCheckBox.TabIndex = 9;
+            this.UseAuthCheckBox.Text = "Use Auth";
+            this.UseAuthCheckBox.UseVisualStyleBackColor = true;
+            this.UseAuthCheckBox.CheckedChanged += new System.EventHandler(this.UseAuthCheckBox_CheckedChanged);
+            // 
+            // AuthUserTextBox
+            // 
+            this.AuthUserTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.AuthUserTextBox.Location = new System.Drawing.Point(74, 143);
+            this.AuthUserTextBox.Name = "AuthUserTextBox";
+            this.AuthUserTextBox.Size = new System.Drawing.Size(138, 21);
+            this.AuthUserTextBox.TabIndex = 10;
+            // 
+            // AuthPwdTextBox
+            // 
+            this.AuthPwdTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.AuthPwdTextBox.Location = new System.Drawing.Point(301, 143);
+            this.AuthPwdTextBox.Name = "AuthPwdTextBox";
+            this.AuthPwdTextBox.PasswordChar = '*';
+            this.AuthPwdTextBox.Size = new System.Drawing.Size(91, 21);
+            this.AuthPwdTextBox.TabIndex = 11;
             // 
             // ProxyForm
             // 
@@ -260,5 +324,10 @@
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Label ProxyNotificationLabel;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.Label AuthUserLabel;
+        private System.Windows.Forms.Label AuthPwdLabel;
+        private System.Windows.Forms.CheckBox UseAuthCheckBox;
+        private System.Windows.Forms.TextBox AuthUserTextBox;
+        private System.Windows.Forms.TextBox AuthPwdTextBox;
     }
 }

--- a/shadowsocks-csharp/View/ProxyForm.cs
+++ b/shadowsocks-csharp/View/ProxyForm.cs
@@ -37,6 +37,9 @@ namespace Shadowsocks.View
             ProxyPortLabel.Text = I18N.GetString("Proxy Port");
             ProxyTimeoutLabel.Text = I18N.GetString("Timeout(Sec)");
             ProxyNotificationLabel.Text = I18N.GetString("If server has a plugin, proxy will not be used");
+            UseAuthCheckBox.Text = I18N.GetString("Use Auth");
+            AuthUserLabel.Text = I18N.GetString("Auth User");
+            AuthPwdLabel.Text = I18N.GetString("Auth Pwd");
             OKButton.Text = I18N.GetString("OK");
             MyCancelButton.Text = I18N.GetString("Cancel");
             this.Text = I18N.GetString("Edit Proxy");
@@ -55,6 +58,9 @@ namespace Shadowsocks.View
             ProxyPortTextBox.Text = _modifiedProxyConfig.proxyPort.ToString();
             ProxyTimeoutTextBox.Text = _modifiedProxyConfig.proxyTimeout.ToString();
             ProxyTypeComboBox.SelectedIndex = _modifiedProxyConfig.proxyType;
+            UseAuthCheckBox.Checked = _modifiedProxyConfig.useAuth;
+            AuthUserTextBox.Text = _modifiedProxyConfig.authUser;
+            AuthPwdTextBox.Text = _modifiedProxyConfig.authPwd;
         }
 
         private void OKButton_Click(object sender, EventArgs e)
@@ -81,6 +87,13 @@ namespace Shadowsocks.View
                     Configuration.CheckServer(_modifiedProxyConfig.proxyServer = ProxyServerTextBox.Text);
                     Configuration.CheckPort(_modifiedProxyConfig.proxyPort);
                     Configuration.CheckTimeout(_modifiedProxyConfig.proxyTimeout, ProxyConfig.MaxProxyTimeoutSec);
+
+                    _modifiedProxyConfig.useAuth = UseAuthCheckBox.Checked;
+                    if (_modifiedProxyConfig.useAuth)
+                    {
+                        Configuration.CheckProxyAuthUser(_modifiedProxyConfig.authUser = AuthUserTextBox.Text);
+                        Configuration.CheckProxyAuthPwd(_modifiedProxyConfig.authPwd = AuthPwdTextBox.Text);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -113,18 +126,62 @@ namespace Shadowsocks.View
         {
             if (UseProxyCheckBox.Checked)
             {
-                ProxyServerTextBox.Enabled = 
-                ProxyPortTextBox.Enabled = 
-                ProxyTimeoutTextBox.Enabled = 
+                ProxyServerTextBox.Enabled =
+                ProxyPortTextBox.Enabled =
+                ProxyTimeoutTextBox.Enabled =
                 ProxyTypeComboBox.Enabled = true;
+
+                if (ProxyTypeComboBox.SelectedIndex == ProxyConfig.PROXY_HTTP)
+                {
+                    UseAuthCheckBox.Enabled = true;
+
+                    if (UseAuthCheckBox.Checked)
+                    {
+                        AuthUserTextBox.Enabled =
+                        AuthPwdTextBox.Enabled = true;
+                    }
+                    else
+                    {
+                        AuthUserTextBox.Enabled =
+                        AuthPwdTextBox.Enabled = false;
+                    }
+                }
+                else
+                {
+                    // TODO support for SOCK5 auth
+                    UseAuthCheckBox.Enabled =
+                    AuthUserTextBox.Enabled =
+                    AuthPwdTextBox.Enabled = false;
+                }
             }
             else
             {
                 ProxyServerTextBox.Enabled =
                 ProxyPortTextBox.Enabled =
                 ProxyTimeoutTextBox.Enabled =
-                ProxyTypeComboBox.Enabled = false; 
+                ProxyTypeComboBox.Enabled =
+                UseAuthCheckBox.Enabled =
+                AuthUserTextBox.Enabled =
+                AuthPwdTextBox.Enabled = false;
             }
+        }
+
+        private void ProxyTypeComboBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            // TODO support for SOCK5 auth
+            if (ProxyTypeComboBox.SelectedIndex != ProxyConfig.PROXY_HTTP)
+            {
+                UseAuthCheckBox.Checked = false;
+                AuthUserTextBox.Clear();
+                AuthPwdTextBox.Clear();
+            }
+
+            UpdateEnabled();
+        }
+
+        private void UseAuthCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateEnabled();
         }
     }
 }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New feature

---

### Description of your *pull request* and other information

Ported from `对正向HTTP代理添加基本认证功能` #1214
Great thanks to @rickryo
![](https://user-images.githubusercontent.com/25237525/27816462-413ac476-60be-11e7-9d6c-18e29d00b26c.png)

* Add "basic access authentication" support for HTTP proxy