### PR TITLE
Use id instead of calculating server.Identifier()

### DIFF
--- a/shadowsocks-csharp/Controller/Strategy/StatisticsStrategy.cs
+++ b/shadowsocks-csharp/Controller/Strategy/StatisticsStrategy.cs
@@ -89,7 +89,7 @@ namespace Shadowsocks.Controller.Strategy
                 var serversWithStatistics = (from server in servers
                     let id = server.Identifier()
                     where _filteredStatistics.ContainsKey(id)
-                    let score = GetScore(server.Identifier(), _filteredStatistics[server.Identifier()])
+                    let score = GetScore(id, _filteredStatistics[id])
                     where score != null
                     select new
                     {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

Use already calculated id variable instead of server.Identifier().