### PR TITLE
Fixed a bug with + in query

### DIFF
--- a/shadowsocks-csharp/Model/Server.cs
+++ b/shadowsocks-csharp/Model/Server.cs
@@ -169,7 +169,7 @@ namespace Shadowsocks.Model
                     server.password = userInfoParts[1];
 
                     NameValueCollection queryParameters = HttpUtility.ParseQueryString(parsedUrl.Query);
-                    string[] pluginParts = HttpUtility.UrlDecode(queryParameters["plugin"] ?? "").Split(new[] { ';' }, 2);
+                    string[] pluginParts = (queryParameters["plugin"] ?? "").Split(new[] { ';' }, 2);
                     if (pluginParts.Length > 0)
                     {
                         server.plugin = pluginParts[0] ?? "";


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

Hello
At first when getting a key value from `NameValueCollection` the URL will be decoded automatically. So there is no need of `HttpUtility.UrlDecode`.
Secondly, try to parse this `ss://` URL with `Import URL From Clipboard`:
```
ss://cmM0LW1kNTpQRzh2OXpHMFJiVkJDQnpm@1.1.1.1:443?plugin=ck-client%3bUID%3dIprWshnjXx3mS3wnWsIFfcvgcvwt4%2bFcoN7%2bIBZA8nU%5c%3d%3bPublicKey%3dD9baLw4qzRhqUDWyyYvuGBTWUP5Tr0NywoB5%2bkbRtWU%5c%3d%3bServerName%3dbing.com%3bTicketTimeHint%3d3600%3bMaskBrowser%3dchrome%3bNumConn%3d4
```
If you go to shadowsocks server's configs and look for plugin options you will notice that there is some white spaces. This is unexpected behavior because these white spaces should be `+` and somehow `HttpUtility.UrlDecode` are replacing them with white space. So with this build I can successfully import my config without any issues.
Also you can try decoding the parameter(from `?` to end) [here](https://www.urldecoder.org/). Notice the `+` signs.