### PR TITLE
Support Windows 10 1903 Light Theme

### DIFF
--- a/shadowsocks-csharp/Util/Util.cs
+++ b/shadowsocks-csharp/Util/Util.cs
@@ -55,6 +55,37 @@ namespace Shadowsocks.Util
             return _tempPath;
         }
 
+        public enum WindowsThemeMode { Dark, Light }
+
+        // Support on Windows 10 1903+
+        public static WindowsThemeMode GetWindows10SystemThemeSetting()
+        {
+            WindowsThemeMode registData = WindowsThemeMode.Dark;
+            try
+            {
+                RegistryKey reg_HKCU = Registry.CurrentUser;
+                RegistryKey reg_ThemesPersonalize = reg_HKCU.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", false);
+                if (reg_ThemesPersonalize.GetValue("SystemUsesLightTheme") != null)
+                {
+                    if (Convert.ToInt32(reg_ThemesPersonalize.GetValue("SystemUsesLightTheme").ToString()) == 0) // 0:dark mode, 1:light mode
+                        registData = WindowsThemeMode.Dark;
+                    else
+                        registData = WindowsThemeMode.Light;
+                    //Console.WriteLine(registData);
+                }
+                else
+                {
+                    throw new Exception("Reg-Value SystemUsesLightTheme not found.");
+                }
+            }
+            catch
+            {
+                Logging.Info(
+                        $"Cannot get Windows 10 system theme mode, return default value 0 (dark mode).");
+            }
+            return registData;
+        }
+
         // return a full path with filename combined which pointed to the temporary directory
         public static string GetTempPath(string filename)
         {

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -86,7 +86,6 @@ namespace Shadowsocks.View
             _notifyIcon.MouseClick += notifyIcon1_Click;
             _notifyIcon.MouseDoubleClick += notifyIcon1_DoubleClick;
             _notifyIcon.BalloonTipClosed += _notifyIcon_BalloonTipClosed;
-            _notifyIcon.MouseMove += _notifyIcon_MouseMove;
             controller.TrafficChanged += controller_TrafficChanged;
 
             this.updateChecker = new UpdateChecker();
@@ -106,11 +105,6 @@ namespace Shadowsocks.View
                 _isStartupChecking = true;
                 updateChecker.CheckUpdate(config, 3000);
             }
-        }
-
-        private void _notifyIcon_MouseMove(object sender, MouseEventArgs e)
-        {
-            UpdateTrayIcon();
         }
 
         private void controller_TrafficChanged(object sender, EventArgs e)
@@ -632,6 +626,7 @@ namespace Shadowsocks.View
 
         private void notifyIcon1_Click(object sender, MouseEventArgs e)
         {
+            UpdateTrayIcon();
             if (e.Button == MouseButtons.Middle)
             {
                 ShowLogForm();

--- a/shadowsocks-csharp/shadowsocks-csharp.csproj
+++ b/shadowsocks-csharp/shadowsocks-csharp.csproj
@@ -83,6 +83,7 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>3rd\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [ ] Improvement
- [x] New feature

---

### Description of your *pull request* and other information

Support Windows 10 1903 light theme. (Menu icon color adaptive, previous version icons are indistinguishable at light theme)
Icon more beautiful. (use alpha replace 128 gray)
支持 Windows10 1903 的“亮”主题色。（菜单图标颜色自适应，之前版本图标会在亮色主题下难以看见）
图标更加美观。（使用Alpha通道替换128灰色）

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.