### PR TITLE
Fix udp relay

### DIFF
--- a/shadowsocks-csharp/Controller/Service/UDPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/UDPRelay.cs
@@ -40,10 +40,10 @@ namespace Shadowsocks.Controller
             if (handler == null)
             {
                 handler = new UDPHandler(socket, _controller.GetAServer(IStrategyCallerType.UDP, remoteEndPoint, null/*TODO: fix this*/), remoteEndPoint);
+                handler.Receive();
                 _cache.add(remoteEndPoint, handler);
             }
             handler.Send(firstPacket, length);
-            handler.Receive();
             return true;
         }
 
@@ -74,6 +74,7 @@ namespace Shadowsocks.Controller
                 }
                 _remoteEndPoint = new IPEndPoint(ipAddress, server.server_port);
                 _remote = new Socket(_remoteEndPoint.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
+                _remote.Bind(new IPEndPoint(IPAddress.Any, 0));
             }
 
             public void Send(byte[] data, int length)


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

Each udp packet sent to UDPHandler fires a new `Receive` loop, which is not expected. There should only be one `Receive` loop in one UDPHandler.

For me, this fixes connection constantly lost when playing _League of Legends_.
