### PR TITLE
纯IPv6本地监听支持

### DIFF
--- a/shadowsocks-csharp/Controller/Service/PACServer.cs
+++ b/shadowsocks-csharp/Controller/Service/PACServer.cs
@@ -51,7 +51,7 @@ namespace Shadowsocks.Controller
                 PacSecret = "";
             }
 
-            PacUrl = $"http://127.0.0.1:{config.localPort}/pac?t={GetTimestamp(DateTime.Now)}{PacSecret}";
+            PacUrl = $"http://{config.LocalHost}:{config.localPort}/pac?t={GetTimestamp(DateTime.Now)}{PacSecret}";
         }
 
 
@@ -101,7 +101,7 @@ namespace Shadowsocks.Controller
                         }
                         if (!secretMatch)
                         {
-                            if(line.IndexOf(PacSecret, StringComparison.Ordinal) >= 0)
+                            if (line.IndexOf(PacSecret, StringComparison.Ordinal) >= 0)
                             {
                                 secretMatch = true;
                             }
@@ -255,7 +255,7 @@ Connection: Close
             if (UserRuleFileChanged != null)
             {
                 Logging.Info($"Detected: User Rule file '{e.Name}' was {e.ChangeType.ToString().ToLower()}.");
-                Task.Factory.StartNew(()=>
+                Task.Factory.StartNew(() =>
                 {
                     ((FileSystemWatcher)sender).EnableRaisingEvents = false;
                     System.Threading.Thread.Sleep(10);
@@ -268,7 +268,9 @@ Connection: Close
 
         private string GetPACAddress(IPEndPoint localEndPoint, bool useSocks)
         {
-            return $"{(useSocks ? "SOCKS5" : "PROXY")} {localEndPoint.Address}:{_config.localPort};";
+            return localEndPoint.AddressFamily == AddressFamily.InterNetworkV6
+                ? $"{(useSocks ? "SOCKS5" : "PROXY")} [{localEndPoint.Address}]:{_config.localPort};"
+                : $"{(useSocks ? "SOCKS5" : "PROXY")} {localEndPoint.Address}:{_config.localPort};";
         }
     }
 }

--- a/shadowsocks-csharp/Controller/Service/PACServer.cs
+++ b/shadowsocks-csharp/Controller/Service/PACServer.cs
@@ -51,7 +51,7 @@ namespace Shadowsocks.Controller
                 PacSecret = "";
             }
 
-            PacUrl = $"http://{config.LocalHost}:{config.localPort}/pac?t={GetTimestamp(DateTime.Now)}{PacSecret}";
+            PacUrl = $"http://{config.localHost}:{config.localPort}/pac?t={GetTimestamp(DateTime.Now)}{PacSecret}";
         }
 
 

--- a/shadowsocks-csharp/Controller/Service/PortForwarder.cs
+++ b/shadowsocks-csharp/Controller/Service/PortForwarder.cs
@@ -49,7 +49,8 @@ namespace Shadowsocks.Controller
                 _local = socket;
                 try
                 {
-                    EndPoint remoteEP = SocketUtil.GetEndPoint("127.0.0.1", targetPort);
+                    // Local Port Forward use IP as is
+                    EndPoint remoteEP = SocketUtil.GetEndPoint(_local.AddressFamily == AddressFamily.InterNetworkV6 ? "[::1]" : "127.0.0.1", targetPort);
 
                     // Connect to the remote endpoint.
                     _remote = new WrappedSocket();

--- a/shadowsocks-csharp/Controller/Service/UDPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/UDPRelay.cs
@@ -58,6 +58,19 @@ namespace Shadowsocks.Controller
             private IPEndPoint _localEndPoint;
             private IPEndPoint _remoteEndPoint;
 
+            private IPAddress GetIPAddress()
+            {
+                switch (_remote.AddressFamily)
+                {
+                    case AddressFamily.InterNetwork:
+                        return IPAddress.Any;
+                    case AddressFamily.InterNetworkV6:
+                        return IPAddress.IPv6Any;
+                    default:
+                        return IPAddress.Any;
+                }
+            }
+
             public UDPHandler(Socket local, Server server, IPEndPoint localEndPoint)
             {
                 _local = local;
@@ -74,7 +87,7 @@ namespace Shadowsocks.Controller
                 }
                 _remoteEndPoint = new IPEndPoint(ipAddress, server.server_port);
                 _remote = new Socket(_remoteEndPoint.AddressFamily, SocketType.Dgram, ProtocolType.Udp);
-                _remote.Bind(new IPEndPoint(IPAddress.Any, 0));
+                _remote.Bind(new IPEndPoint(GetIPAddress(), 0));
             }
 
             public void Send(byte[] data, int length)
@@ -91,7 +104,7 @@ namespace Shadowsocks.Controller
 
             public void Receive()
             {
-                EndPoint remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
+                EndPoint remoteEndPoint = new IPEndPoint(GetIPAddress(), 0);
                 Logging.Debug($"++++++Receive Server Port, size:" + _buffer.Length);
                 _remote?.BeginReceiveFrom(_buffer, 0, _buffer.Length, 0, ref remoteEndPoint, new AsyncCallback(RecvFromCallback), null);
             }
@@ -101,7 +114,7 @@ namespace Shadowsocks.Controller
                 try
                 {
                     if (_remote == null) return;
-                    EndPoint remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
+                    EndPoint remoteEndPoint = new IPEndPoint(GetIPAddress(), 0);
                     int bytesRead = _remote.EndReceiveFrom(ar, ref remoteEndPoint);
 
                     byte[] dataOut = new byte[bytesRead];

--- a/shadowsocks-csharp/Controller/Service/UpdateChecker.cs
+++ b/shadowsocks-csharp/Controller/Service/UpdateChecker.cs
@@ -84,7 +84,7 @@ namespace Shadowsocks.Controller
                 {
                     foreach (JObject release in result)
                     {
-                        var isPreRelease = (bool) release["prerelease"];
+                        var isPreRelease = (bool)release["prerelease"];
                         if (isPreRelease && !config.checkPreRelease)
                         {
                             continue;
@@ -170,7 +170,7 @@ namespace Shadowsocks.Controller
         {
             WebClient http = new WebClient();
             http.Headers.Add("User-Agent", UserAgent);
-            http.Proxy = new WebProxy(IPAddress.Loopback.ToString(), config.localPort);
+            http.Proxy = new WebProxy(config.LocalHost, config.localPort);
             return http;
         }
 
@@ -189,7 +189,7 @@ namespace Shadowsocks.Controller
 
             public static Asset ParseAsset(JObject assertJObject)
             {
-                var name = (string) assertJObject["name"];
+                var name = (string)assertJObject["name"];
                 Match match = Regex.Match(name, @"^Shadowsocks-(?<version>\d+(?:\.\d+)*)(?:|-(?<suffix>.+))\.\w+$",
                     RegexOptions.IgnoreCase);
                 if (match.Success)
@@ -198,7 +198,7 @@ namespace Shadowsocks.Controller
 
                     var asset = new Asset
                     {
-                        browser_download_url = (string) assertJObject["browser_download_url"],
+                        browser_download_url = (string)assertJObject["browser_download_url"],
                         name = name,
                         version = version
                     };

--- a/shadowsocks-csharp/Controller/Service/UpdateChecker.cs
+++ b/shadowsocks-csharp/Controller/Service/UpdateChecker.cs
@@ -170,7 +170,7 @@ namespace Shadowsocks.Controller
         {
             WebClient http = new WebClient();
             http.Headers.Add("User-Agent", UserAgent);
-            http.Proxy = new WebProxy(config.LocalHost, config.localPort);
+            http.Proxy = new WebProxy(config.localHost, config.localPort);
             return http;
         }
 

--- a/shadowsocks-csharp/Controller/System/SystemProxy.cs
+++ b/shadowsocks-csharp/Controller/System/SystemProxy.cs
@@ -28,7 +28,7 @@ namespace Shadowsocks.Controller
                 {
                     if (global)
                     {
-                        Sysproxy.SetIEProxy(true, true, "127.0.0.1:" + config.localPort.ToString(), null);
+                        Sysproxy.SetIEProxy(true, true, "localhost:" + config.localPort.ToString(), null);
                     }
                     else
                     {

--- a/shadowsocks-csharp/Data/privoxy_conf.txt
+++ b/shadowsocks-csharp/Data/privoxy_conf.txt
@@ -3,6 +3,6 @@ toggle 0
 logfile ss_privoxy.log
 show-on-task-bar 0
 activity-animation 0
-forward-socks5 / 127.0.0.1:__SOCKS_PORT__ .
+forward-socks5 / __SOCKS_HOST__:__SOCKS_PORT__ .
 max-client-connections 2048
 hide-console

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -36,8 +36,8 @@ namespace Shadowsocks.Model
         public HotkeyConfig hotkey;
 
         private static string CONFIG_FILE = "gui-config.json";
-
-        public string LocalHost => GetLocalHost();
+        [JsonIgnore]
+        public string localHost => GetLocalHost();
         private string GetLocalHost() {
             return isIPv6Enabled ? "[::1]" : "127.0.0.1";
         }

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -21,6 +21,7 @@ namespace Shadowsocks.Model
         public bool enabled;
         public bool shareOverLan;
         public bool isDefault;
+        public bool isIPv6Enabled = false;
         public int localPort;
         public bool portableMode = true;
         public string pacUrl;
@@ -36,6 +37,10 @@ namespace Shadowsocks.Model
 
         private static string CONFIG_FILE = "gui-config.json";
 
+        public string LocalHost => GetLocalHost();
+        private string GetLocalHost() {
+            return isIPv6Enabled ? "[::1]" : "127.0.0.1";
+        }
         public Server GetCurrentServer()
         {
             if (index >= 0 && index < configs.Count)
@@ -74,6 +79,10 @@ namespace Shadowsocks.Model
                     config.proxy = new ProxyConfig();
                 if (config.hotkey == null)
                     config.hotkey = new HotkeyConfig();
+                if (!System.Net.Sockets.Socket.OSSupportsIPv6) {
+                    config.isIPv6Enabled = false; // disable IPv6 if os not support
+                }
+                //TODO if remote host(server) do not support IPv6 (or DNS resolve AAAA TYPE record) disable IPv6?
 
                 config.proxy.CheckConfig();
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [x] New feature

---

### Description of your *pull request* and other information

增加IPv6 本地监听功能【纯IPv6，启用后不再监听IPv4】
* 如果同时启用IPv4和IPv6 则需要考虑更多的问题。目前只做纯IPv4/IPv6
针对#2407 的一种解决方案 
增加了`isIPv6Enabled` 标记，默认仍为关闭保持原样。
![image](https://user-images.githubusercontent.com/6064040/59751564-5b4bb400-92b3-11e9-8eb3-50715ef79c2b.png)

当手动修改配置文件`gui-config.json`后 增加或者修改 
``` isIPv6Enabled = true```
后，将启用纯IPv6模式，原IPv4 监听的 1080 [tcp/udp] `ss_privoxy`随机 都将默认从IPv4切换到IPv6
`0.0.0.0`->`[::]`,`127.0.0.1`->`[::1]` 
切换后如图【允许其他设备接入】
![image](https://user-images.githubusercontent.com/6064040/59750994-54707180-92b2-11e9-8f84-bcbca8935de7.png)
关闭【允许其他设备接入】
![image](https://user-images.githubusercontent.com/6064040/59751358-f4c69600-92b2-11e9-98d4-483f2643976a.png)

存在的瑕疵：
目前有一个参数 `LocalHost` 会被写入到配置文件，但我不希望写入，这个需要解决。
代码中 `LocalHost=>GetLocalHost()` 是希望其他地方可以像`localPort`参数一样引用这个动态的`localHost` ，但对c#不熟悉所以不知道如何让 json 把这个 参数当成普通参数不进行json序列化。