### PR TITLE
Turn off per-monitor DPI awareness as it is not supported

### DIFF
--- a/shadowsocks-csharp/app.manifest
+++ b/shadowsocks-csharp/app.manifest
@@ -10,7 +10,7 @@
   </trustInfo>
   <asmv3:application>
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
-      <dpiAware>True/PM</dpiAware>
+      <dpiAware>true</dpiAware>
     </asmv3:windowsSettings>
   </asmv3:application>
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

This is the first fix for #2426, also the quickest and dirtiest as the UI will become blurry in the secondary display.

Basically it reverts a change: https://github.com/shadowsocks/shadowsocks-windows/commit/1e072e5f917e65d8ba1251848748d814894b4c2c#diff-dc2430a5071a2f8e51b6cd9abc1adc5bL13

To test you may try: https://github.com/prasethu/RemoteDesktopEmulator