### PR TITLE
Added capability of specifying nicknames of the servers

### DIFF
--- a/shadowsocks-csharp/Model/Server.cs
+++ b/shadowsocks-csharp/Model/Server.cs
@@ -29,6 +29,7 @@ namespace Shadowsocks.Model
         public string plugin_args;
         public string remarks;
         public int timeout;
+        public string nick_name;
 
         public override int GetHashCode()
         {
@@ -48,7 +49,7 @@ namespace Shadowsocks.Model
                 return I18N.GetString("New server");
             }
 
-            string serverStr = $"{FormatHostName(server)}:{server_port}";
+            string serverStr = this.nick_name.IsNullOrEmpty() ? $"{FormatHostName(server)}:{server_port}" : this.nick_name;
             return remarks.IsNullOrEmpty()
                 ? serverStr
                 : $"{remarks} ({serverStr})";

--- a/shadowsocks-csharp/View/ConfigForm.Designer.cs
+++ b/shadowsocks-csharp/View/ConfigForm.Designer.cs
@@ -50,6 +50,8 @@
             this.PluginArgumentsLabel = new System.Windows.Forms.Label();
             this.RemarksLabel = new System.Windows.Forms.Label();
             this.NeedPluginArgCheckBox = new System.Windows.Forms.CheckBox();
+            this.NickNameLabel = new System.Windows.Forms.Label();
+            this.NickNameTextBox = new System.Windows.Forms.TextBox();
             this.panel2 = new System.Windows.Forms.Panel();
             this.OKButton = new System.Windows.Forms.Button();
             this.MyCancelButton = new System.Windows.Forms.Button();
@@ -106,11 +108,14 @@
             this.tableLayoutPanel1.Controls.Add(this.PluginArgumentsLabel, 0, 8);
             this.tableLayoutPanel1.Controls.Add(this.RemarksLabel, 0, 10);
             this.tableLayoutPanel1.Controls.Add(this.NeedPluginArgCheckBox, 1, 7);
+            this.tableLayoutPanel1.Controls.Add(this.NickNameLabel, 0, 12);
+            this.tableLayoutPanel1.Controls.Add(this.NickNameTextBox, 1, 12);
             this.tableLayoutPanel1.Location = new System.Drawing.Point(8, 21);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.Padding = new System.Windows.Forms.Padding(3);
-            this.tableLayoutPanel1.RowCount = 12;
+            this.tableLayoutPanel1.RowCount = 13;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -630,6 +635,26 @@
             this.DuplicateButton.UseVisualStyleBackColor = true;
             this.DuplicateButton.Click += new System.EventHandler(this.DuplicateButton_Click);
             // 
+            // NickNameLabel
+            // 
+            this.NickNameLabel.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.NickNameLabel.AutoSize = true;
+            this.NickNameLabel.Location = new System.Drawing.Point(30, 296);
+            this.NickNameLabel.Name = "NickNameLabel";
+            this.NickNameLabel.Size = new System.Drawing.Size(77, 12);
+            this.NickNameLabel.TabIndex = 0;
+            this.NickNameLabel.Text = "Nickname";
+            // 
+            // NickNameTextBox
+            // 
+            this.NickNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.NickNameTextBox.Location = new System.Drawing.Point(113, 292);
+            this.NickNameTextBox.MaxLength = 512;
+            this.NickNameTextBox.Name = "NickNameTextBox";
+            this.NickNameTextBox.Size = new System.Drawing.Size(160, 21);
+            this.NickNameTextBox.TabIndex = 0;
+            this.NickNameTextBox.WordWrap = false;
+            // 
             // ConfigForm
             // 
             this.AcceptButton = this.OKButton;
@@ -710,6 +735,8 @@
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.CheckBox PortableModeCheckBox;
         private System.Windows.Forms.CheckBox NeedPluginArgCheckBox;
+        private System.Windows.Forms.Label NickNameLabel;
+        private System.Windows.Forms.TextBox NickNameTextBox;
     }
 }
 


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information
Added capability of specifying nicknames of the servers
Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.
Currently after a server is added, the server list would show the server address as an indicator of the server entry. However, an IP address is not a very user friendly indicator for human beings, especially when you have added multiple server entries.
This usability improvement would allow you to specify an optional nickname of the server entry. For example, you could give nickname "Server 1" to server "xxx.xxx.xxx.xxx". If the nickname is specified, it will be displayed in the server list and system tray menu, instead of the actual server address.