### PR TITLE
pagerize servers in menu

### DIFF
--- a/shadowsocks-csharp/Data/zh_CN.txt
+++ b/shadowsocks-csharp/Data/zh_CN.txt
@@ -39,6 +39,8 @@ Edit Servers=编辑服务器
 Load Balance=负载均衡
 High Availability=高可用
 Choose by statistics=根据统计
+Next Page=下一页
+✔Next Page=✔下一页
 
 # Config Form
 

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -473,7 +473,7 @@ namespace Shadowsocks.View
                     MenuItem item = new MenuItem(server.FriendlyName());
                     item.Tag = serverIndex;
                     item.Click += AServerItem_Click;
-                    if (serverIndex > MAX_DISPLAY_SERVER_PER_PAGE)
+                    if (serverIndex >= MAX_DISPLAY_SERVER_PER_PAGE)
                     {
                         if (moreServersPages.Count != 0 && moreServersPages.Last().MenuItems.Count < MAX_DISPLAY_SERVER_PER_PAGE)
                         {


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information
Some airports provides with a large potential server list, typically 100+, which makes selecting a server from tray context menu unavailable.
some issuers wants a ScrollViewer-like thing in menu, it seems impossible in  WinForm.
So pagerizing them seems nice.
associated issue: #2472 
it looks like this:
![a_screenshot](https://user-images.githubusercontent.com/16681599/66038728-8649d300-e545-11e9-8d79-c8a989a84a04.png)
![b_screenshot](https://user-images.githubusercontent.com/16681599/66038768-9f528400-e545-11e9-83b0-361b60af0c95.png)

