### PR TITLE
[Don't merge] Implement the dual stack IPv4 IPv6

### DIFF
--- a/shadowsocks-csharp/Controller/Service/Listener.cs
+++ b/shadowsocks-csharp/Controller/Service/Listener.cs
@@ -115,14 +115,13 @@ namespace Shadowsocks.Controller
             UDPState state = (UDPState)ar.AsyncState;
             var socket = state.socket;
 
-            IPAddress remoteIpAddress = ((IPEndPoint)socket.RemoteEndPoint).Address;
-            if (!_config.shareOverLan && !remoteIpAddress.Equals(IPAddress.IPv6Loopback) && !remoteIpAddress.Equals(IPAddress.Loopback.MapToIPv6()))
-            {
-                return;
-            }
-
             try
             {
+                IPAddress remoteIpAddress = ((IPEndPoint)socket.RemoteEndPoint).Address;
+                if (!_config.shareOverLan && !remoteIpAddress.Equals(IPAddress.IPv6Loopback) && !remoteIpAddress.Equals(IPAddress.Loopback.MapToIPv6()))
+                {
+                    return;
+                }
                 int bytesRead = socket.EndReceiveFrom(ar, ref state.remoteEndPoint);
                 foreach (IService service in _services)
                 {

--- a/shadowsocks-csharp/Controller/Service/PACServer.cs
+++ b/shadowsocks-csharp/Controller/Service/PACServer.cs
@@ -7,7 +7,6 @@ using System.Net.Sockets;
 using System.Text;
 using Shadowsocks.Encryption;
 using Shadowsocks.Model;
-using Shadowsocks.Properties;
 using Shadowsocks.Util;
 using System.Threading.Tasks;
 
@@ -213,9 +212,9 @@ Connection: Close
 
         private string GetPACAddress(IPEndPoint localEndPoint, bool useSocks)
         {
-            return _config.isIPv6Enabled
-                ? $"{(useSocks ? "SOCKS5" : "PROXY")} [{localEndPoint.Address}]:{_config.localPort};"
-                : $"{(useSocks ? "SOCKS5" : "PROXY")} {localEndPoint.Address.MapToIPv4()}:{_config.localPort};";
+            return localEndPoint.Address.IsIPv4MappedToIPv6
+                ? $"{(useSocks ? "SOCKS5" : "PROXY")} {localEndPoint.Address.MapToIPv4()}:{_config.localPort};"
+                : $"{(useSocks ? "SOCKS5" : "PROXY")} [{localEndPoint.Address}]:{_config.localPort};";
         }
     }
 }

--- a/shadowsocks-csharp/Controller/Service/PortForwarder.cs
+++ b/shadowsocks-csharp/Controller/Service/PortForwarder.cs
@@ -50,7 +50,7 @@ namespace Shadowsocks.Controller
                 try
                 {
                     // Local Port Forward use IP as is
-                    EndPoint remoteEP = SocketUtil.GetEndPoint(_local.AddressFamily == AddressFamily.InterNetworkV6 ? "[::1]" : "127.0.0.1", targetPort);
+                    EndPoint remoteEP = SocketUtil.GetEndPoint(((IPEndPoint)_local.LocalEndPoint).Address.IsIPv4MappedToIPv6 ? "127.0.0.1" : "[::1]", targetPort);
 
                     // Connect to the remote endpoint.
                     _remote = new WrappedSocket();

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -479,10 +479,10 @@ namespace Shadowsocks.Controller
 
             if (_pacServer == null)
             {
-                _pacServer = new PACServer(_pacDaemon);
+                _pacServer = new PACServer(_pacDaemon, _config);
             }
 
-            _pacServer.UpdatePACURL(_config);
+            _pacServer.UpdatePACURL();
             if (gfwListUpdater == null)
             {
                 gfwListUpdater = new GFWListUpdater();


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [x] New feature

---

### Description of your *pull request* and other information

Dual stack on both IPv4 and IPv6.

- PAC url and provixy v4v6 preference is controlled by `isIPv6Enabled` in `gui-config.json`
- Socks5 interface is always listening on both v4 and v6.


Impact:
It will always listening on IPv6 from all interfaces (not loop only) because the incoming v4 request is mapped to `[::ffff:127.0.0.1]`. (For TCP) After accept the connect request, if "shareOverLan" is disabled and the request source is not localhost, close the connection.