### PR TITLE
BugFix #2657 win10 1903 黑色主题下， trayIcon 会消失的问题；

### DIFF
--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -66,7 +66,7 @@ namespace Shadowsocks.View
         // color definition for icon color transformation
         private readonly Color colorMaskBlue = Color.FromArgb(255, 25, 125, 191);
         private readonly Color colorMaskDarkSilver = Color.FromArgb(128, 192, 192, 192);
-        private readonly Color colorMaskLightSilver = Color.FromArgb(192, 192, 192, 192);
+        private readonly Color colorMaskLightSilver = Color.FromArgb(192, 192, 192);
         private readonly Color colorMaskEclipse = Color.FromArgb(192, 64, 64, 64);
 
         public MenuViewController(ShadowsocksController controller)


### PR DESCRIPTION
Fixes https://github.com/shadowsocks/shadowsocks-windows/issues/2657

Support Windows 10 1903 Light Theme

But Fix Support Windows 10 1903 Dark Theme

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [x] Bug fix
---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.