### PR TITLE
Implement "Show Plugin Output" checkbox.

### DIFF
--- a/shadowsocks-csharp/Controller/Service/Sip003Plugin.cs
+++ b/shadowsocks-csharp/Controller/Service/Sip003Plugin.cs
@@ -22,7 +22,7 @@ namespace Shadowsocks.Controller.Service
         private bool _started;
         private bool _disposed;
 
-        public static Sip003Plugin CreateIfConfigured(Server server)
+        public static Sip003Plugin CreateIfConfigured(Server server, bool showPluginOutput)
         {
             if (server == null)
             {
@@ -34,10 +34,16 @@ namespace Shadowsocks.Controller.Service
                 return null;
             }
 
-            return new Sip003Plugin(server.plugin, server.plugin_opts, server.plugin_args, server.server, server.server_port);
+            return new Sip003Plugin(
+                server.plugin,
+                server.plugin_opts,
+                server.plugin_args,
+                server.server,
+                server.server_port,
+                showPluginOutput);
         }
 
-        private Sip003Plugin(string plugin, string pluginOpts, string pluginArgs, string serverAddress, int serverPort)
+        private Sip003Plugin(string plugin, string pluginOpts, string pluginArgs, string serverAddress, int serverPort, bool showPluginOutput)
         {
             if (plugin == null) throw new ArgumentNullException(nameof(plugin));
             if (string.IsNullOrWhiteSpace(serverAddress))
@@ -58,7 +64,7 @@ namespace Shadowsocks.Controller.Service
                     FileName = plugin,
                     Arguments = pluginArgs,
                     UseShellExecute = false,
-                    CreateNoWindow = true,
+                    CreateNoWindow = !showPluginOutput,
                     ErrorDialog = false,
                     WindowStyle = ProcessWindowStyle.Hidden,
                     WorkingDirectory = appPath ?? Environment.CurrentDirectory,

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -65,6 +65,7 @@ namespace Shadowsocks.Controller
         public event EventHandler EnableGlobalChanged;
         public event EventHandler ShareOverLANStatusChanged;
         public event EventHandler VerboseLoggingStatusChanged;
+        public event EventHandler ShowPluginOutputChanged;
         public event EventHandler TrafficChanged;
 
         // when user clicked Edit PAC, and PAC file has already created
@@ -151,7 +152,10 @@ namespace Shadowsocks.Controller
 
         public EndPoint GetPluginLocalEndPointIfConfigured(Server server)
         {
-            var plugin = _pluginsByServer.GetOrAdd(server, Sip003Plugin.CreateIfConfigured);
+            var plugin = _pluginsByServer.GetOrAdd(
+                server,
+                x => Sip003Plugin.CreateIfConfigured(x, _config.showPluginOutput));
+
             if (plugin == null)
             {
                 return null;
@@ -250,6 +254,14 @@ namespace Shadowsocks.Controller
             SaveConfig(_config);
 
             VerboseLoggingStatusChanged?.Invoke(this, new EventArgs());
+        }
+
+        public void ToggleShowPluginOutput(bool enabled)
+        {
+            _config.showPluginOutput = enabled;
+            SaveConfig(_config);
+
+            ShowPluginOutputChanged?.Invoke(this, new EventArgs());
         }
 
         public void SelectServerIndex(int index)

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -23,6 +23,7 @@ namespace Shadowsocks.Model
         public bool isIPv6Enabled = false;
         public int localPort;
         public bool portableMode = true;
+        public bool showPluginOutput;
         public string pacUrl;
         public bool useOnlinePac;
         public bool secureLocalPac = true;

--- a/shadowsocks-csharp/View/MenuViewController.cs
+++ b/shadowsocks-csharp/View/MenuViewController.cs
@@ -55,6 +55,7 @@ namespace Shadowsocks.View
         private MenuItem proxyItem;
         private MenuItem hotKeyItem;
         private MenuItem VerboseLoggingToggleItem;
+        private MenuItem ShowPluginOutputToggleItem;
 
         private ConfigForm configForm;
         private ProxyForm proxyForm;
@@ -81,6 +82,7 @@ namespace Shadowsocks.View
             controller.UserRuleFileReadyToOpen += controller_FileReadyToOpen;
             controller.ShareOverLANStatusChanged += controller_ShareOverLANStatusChanged;
             controller.VerboseLoggingStatusChanged += controller_VerboseLoggingStatusChanged;
+            controller.ShowPluginOutputChanged += controller_ShowPluginOutputChanged;
             controller.EnableGlobalChanged += controller_EnableGlobalChanged;
             controller.Errored += controller_Errored;
             controller.UpdatePACFromGFWListCompleted += controller_UpdatePACFromGFWListCompleted;
@@ -319,6 +321,7 @@ namespace Shadowsocks.View
                 CreateMenuGroup("Help", new MenuItem[] {
                     CreateMenuItem("Show Logs...", new EventHandler(this.ShowLogItem_Click)),
                     this.VerboseLoggingToggleItem = CreateMenuItem( "Verbose Logging", new EventHandler(this.VerboseLoggingToggleItem_Click) ),
+                    this.ShowPluginOutputToggleItem = CreateMenuItem("Show Plugin Output", new EventHandler(this.ShowPluginOutputToggleItem_Click)),
                     CreateMenuGroup("Updates...", new MenuItem[] {
                         CreateMenuItem("Check for Updates...", new EventHandler(this.checkUpdatesItem_Click)),
                         new MenuItem("-"),
@@ -353,6 +356,11 @@ namespace Shadowsocks.View
         void controller_VerboseLoggingStatusChanged(object sender, EventArgs e)
         {
             VerboseLoggingToggleItem.Checked = controller.GetConfigurationCopy().isVerboseLogging;
+        }
+
+        void controller_ShowPluginOutputChanged(object sender, EventArgs e)
+        {
+            ShowPluginOutputToggleItem.Checked = controller.GetConfigurationCopy().showPluginOutput;
         }
 
         void controller_EnableGlobalChanged(object sender, EventArgs e)
@@ -431,6 +439,7 @@ namespace Shadowsocks.View
             UpdateSystemProxyItemsEnabledStatus(config);
             ShareOverLANItem.Checked = config.shareOverLan;
             VerboseLoggingToggleItem.Checked = config.isVerboseLogging;
+            ShowPluginOutputToggleItem.Checked = config.showPluginOutput;
             AutoStartupItem.Checked = AutoStartup.Check();
             onlinePACItem.Checked = onlinePACItem.Enabled && config.useOnlinePac;
             localPACItem.Checked = !onlinePACItem.Checked;
@@ -701,6 +710,12 @@ namespace Shadowsocks.View
         {
             VerboseLoggingToggleItem.Checked = !VerboseLoggingToggleItem.Checked;
             controller.ToggleVerboseLogging(VerboseLoggingToggleItem.Checked);
+        }
+
+        private void ShowPluginOutputToggleItem_Click(object sender, EventArgs e)
+        {
+            ShowPluginOutputToggleItem.Checked = !ShowPluginOutputToggleItem.Checked;
+            controller.ToggleShowPluginOutput(ShowPluginOutputToggleItem.Checked);
         }
 
         private void StatisticsConfigItem_Click(object sender, EventArgs e)

--- a/test/Sip003PluginTest.cs
+++ b/test/Sip003PluginTest.cs
@@ -19,13 +19,15 @@ namespace Shadowsocks.Test
         {
 
 
-            var NoPlugin = Sip003Plugin.CreateIfConfigured(new Server
-            {
-                server = "192.168.100.1",
-                server_port = 8888,
-                password = "test",
-                method = "bf-cfb"
-            });
+            var NoPlugin = Sip003Plugin.CreateIfConfigured(
+                new Server
+                {
+                    server = "192.168.100.1",
+                    server_port = 8888,
+                    password = "test",
+                    method = "bf-cfb"
+                },
+                false);
 
             RunPluginSupportTest(
                 NoPlugin,
@@ -39,14 +41,17 @@ namespace Shadowsocks.Test
         [TestMethod]
         public void TestSip003Plugin_Plugin()
         {
-            var Plugin = Sip003Plugin.CreateIfConfigured(new Server
-            {
-                server = "192.168.100.1",
-                server_port = 8888,
-                password = "test",
-                method = "bf-cfb",
-                plugin = fake_plugin
-            });
+            var Plugin = Sip003Plugin.CreateIfConfigured(
+                new Server
+                {
+                    server = "192.168.100.1",
+                    server_port = 8888,
+                    password = "test",
+                    method = "bf-cfb",
+                    plugin = fake_plugin
+                },
+                false);
+
             RunPluginSupportTest(
                 Plugin,
                 fake_plugin,
@@ -58,16 +63,19 @@ namespace Shadowsocks.Test
 
         [TestMethod]
         public void TestSip003Plugin_PluginWithOpts()
-        { 
-            var PluginWithOpts = Sip003Plugin.CreateIfConfigured(new Server
-            {
-                server = "192.168.100.1",
-                server_port = 8888,
-                password = "test",
-                method = "bf-cfb",
-                plugin = fake_plugin,
-                plugin_opts = "_option"
-            });
+        {
+            var PluginWithOpts = Sip003Plugin.CreateIfConfigured(
+                new Server
+                {
+                    server = "192.168.100.1",
+                    server_port = 8888,
+                    password = "test",
+                    method = "bf-cfb",
+                    plugin = fake_plugin,
+                    plugin_opts = "_option"
+                },
+                false);
+
             RunPluginSupportTest(
                 PluginWithOpts,
                 fake_plugin,
@@ -80,15 +88,18 @@ namespace Shadowsocks.Test
         [TestMethod]
         public void TestSip003Plugin_PluginWithArgs()
         {
-            var PluginWithArgs = Sip003Plugin.CreateIfConfigured(new Server
-            {
-                server = "192.168.100.1",
-                server_port = 8888,
-                password = "test",
-                method = "bf-cfb",
-                plugin = fake_plugin,
-                plugin_args = "_test"
-            });
+            var PluginWithArgs = Sip003Plugin.CreateIfConfigured(
+                new Server
+                {
+                    server = "192.168.100.1",
+                    server_port = 8888,
+                    password = "test",
+                    method = "bf-cfb",
+                    plugin = fake_plugin,
+                    plugin_args = "_test"
+                },
+                false);
+
             RunPluginSupportTest(
                 PluginWithArgs,
                 fake_plugin,
@@ -101,16 +112,19 @@ namespace Shadowsocks.Test
         [TestMethod]
         public void TestSip003Plugin_PluginWithOptsAndArgs()
         {
-            var PluginWithOptsAndArgs = Sip003Plugin.CreateIfConfigured(new Server
-            {
-                server = "192.168.100.1",
-                server_port = 8888,
-                password = "test",
-                method = "bf-cfb",
-                plugin = fake_plugin,
-                plugin_opts = "_option",
-                plugin_args = "_test"
-            });
+            var PluginWithOptsAndArgs = Sip003Plugin.CreateIfConfigured(
+                new Server
+                {
+                    server = "192.168.100.1",
+                    server_port = 8888,
+                    password = "test",
+                    method = "bf-cfb",
+                    plugin = fake_plugin,
+                    plugin_opts = "_option",
+                    plugin_args = "_test"
+                },
+                false);
+
             RunPluginSupportTest(
                 PluginWithOptsAndArgs,
                 fake_plugin,
@@ -123,15 +137,18 @@ namespace Shadowsocks.Test
         [TestMethod]
         public void TestSip003Plugin_PluginWithArgsReplaced()
         {
-            var PluginWithArgsReplaced = Sip003Plugin.CreateIfConfigured(new Server
-            {
-                server = "192.168.100.1",
-                server_port = 8888,
-                password = "test",
-                method = "bf-cfb",
-                plugin = fake_plugin,
-                plugin_args = "_test,%SS_REMOTE_HOST%"
-            });
+            var PluginWithArgsReplaced = Sip003Plugin.CreateIfConfigured(
+                new Server
+                {
+                    server = "192.168.100.1",
+                    server_port = 8888,
+                    password = "test",
+                    method = "bf-cfb",
+                    plugin = fake_plugin,
+                    plugin_args = "_test,%SS_REMOTE_HOST%"
+                },
+                false);
+
             RunPluginSupportTest(
                 PluginWithArgsReplaced,
                 fake_plugin,
@@ -143,17 +160,20 @@ namespace Shadowsocks.Test
 
         [TestMethod]
         public void TestSip003Plugin_PluginWithOptsAndArgsReplaced()
-        { 
-            var PluginWithOptsAndArgsReplaced = Sip003Plugin.CreateIfConfigured(new Server
-            {
-                server = "192.168.100.1",
-                server_port = 8888,
-                password = "test",
-                method = "bf-cfb",
-                plugin = fake_plugin,
-                plugin_opts = "_option",
-                plugin_args = "_test,%SS_REMOTE_HOST%,%SS_PLUGIN_OPTIONS%"
-            });
+        {
+            var PluginWithOptsAndArgsReplaced = Sip003Plugin.CreateIfConfigured(
+                new Server
+                {
+                    server = "192.168.100.1",
+                    server_port = 8888,
+                    password = "test",
+                    method = "bf-cfb",
+                    plugin = fake_plugin,
+                    plugin_opts = "_option",
+                    plugin_args = "_test,%SS_REMOTE_HOST%,%SS_PLUGIN_OPTIONS%"
+                },
+                false);
+
             RunPluginSupportTest(
                 PluginWithOptsAndArgsReplaced,
                 fake_plugin,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

---

This is a simple improvement that allows viewing the plugin output window instead of always hiding it. It can be very useful to debug plugin issues instead of being forced to duplicate the config and run the plugin standalone just to see its output.