### PR TITLE
Update TCPHandler.lastActivity upon successful send of bytes.

### DIFF
--- a/shadowsocks-csharp/Controller/Service/TCPRelay.cs
+++ b/shadowsocks-csharp/Controller/Service/TCPRelay.cs
@@ -924,6 +924,12 @@ namespace Shadowsocks.Controller
                 var session = (AsyncSession)container[0];
                 var bytesShouldSend = (int)container[1];
                 int bytesSent = session.Remote.EndSend(ar);
+
+                if (bytesSent > 0)
+                {
+                    lastActivity = DateTime.Now;
+                }
+
                 int bytesRemaining = bytesShouldSend - bytesSent;
                 if (bytesRemaining > 0)
                 {


### PR DESCRIPTION
Fixes https://github.com/shadowsocks/shadowsocks-windows/issues/2857