### PR TITLE
Fix improperly parsed remark section

### DIFF
--- a/shadowsocks-csharp/Model/Server.cs
+++ b/shadowsocks-csharp/Model/Server.cs
@@ -189,7 +189,8 @@ namespace Shadowsocks.Model
                 }
                 Server server = new Server
                 {
-                    remarks = parsedUrl.GetComponents(UriComponents.Fragment, UriFormat.Unescaped),
+                    remarks = HttpUtility.UrlDecode(parsedUrl.GetComponents(
+                        UriComponents.Fragment, UriFormat.Unescaped), Encoding.UTF8),
                     server = parsedUrl.IdnHost,
                     server_port = parsedUrl.Port,
                 };

--- a/test/UrlTest.cs
+++ b/test/UrlTest.cs
@@ -46,9 +46,9 @@ namespace Shadowsocks.Test
                 server_port = server1.server_port,
                 password = server1.password,
                 method = server1.method,
-                remarks = "example-server"
+                remarks = "example-server 1"
             };
-            server1WithRemarkCanonUrl = "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xMDAuMTo4ODg4#example-server";
+            server1WithRemarkCanonUrl = "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xMDAuMTo4ODg4#example-server+1";
 
             server2WithRemark = new Server
             {
@@ -56,10 +56,10 @@ namespace Shadowsocks.Test
                 server_port = server2.server_port,
                 password = server2.password,
                 method = server2.method,
-                remarks = "example-server"
+                remarks = "example-server 2"
             };
 
-            server2WithRemarkCanonUrl = "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xLjE6ODM4OA==#example-server";
+            server2WithRemarkCanonUrl = "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xLjE6ODM4OA==#example-server+2";
 
             server1WithPlugin = new Server
             {
@@ -96,7 +96,7 @@ namespace Shadowsocks.Test
                 remarks = server1WithRemark.remarks
             };
             server1WithPluginAndRemarkCanonUrl =
-                "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com#example-server";
+                "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com#example-server+1";
 
             server2WithPluginAndRemark = new Server
             {
@@ -109,7 +109,7 @@ namespace Shadowsocks.Test
                 remarks = server2WithRemark.remarks
             };
             server2WithPluginAndRemarkCanonUrl =
-                "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com#example-server";
+                "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com#example-server+2";
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ namespace Shadowsocks.Test
                     "\r\n",
                     "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xMDAuMTo4ODg4/",
                     server1WithRemarkCanonUrl,
-                    "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xMDAuMTo4ODg4/#example-server"),
+                    "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xMDAuMTo4ODg4/#example-server+1"),
                 new[]
                 {
                     server1,
@@ -137,11 +137,11 @@ namespace Shadowsocks.Test
                     "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888",
                     "\r\n",
                     "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/",
-                    "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888#example-server",
-                    "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/#example-server",
+                    "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888#example-server+1",
+                    "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/#example-server+1",
                     server1WithPluginCanonUrl,
                     server1WithPluginAndRemarkCanonUrl,
-                    "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com&unsupported=1#example-server"),
+                    "ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com&unsupported=1#example-server+1"),
                 new[]
                 {
                     server1,
@@ -166,7 +166,7 @@ namespace Shadowsocks.Test
                     "\r\n",
                     "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xLjE6ODM4OA==/",
                     server2WithRemarkCanonUrl,
-                    "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xLjE6ODM4OA==/#example-server"),
+                    "ss://YmYtY2ZiOnRlc3RAMTkyLjE2OC4xLjE6ODM4OA==/#example-server+2"),
                 new[]
                 {
                     server2,
@@ -181,11 +181,11 @@ namespace Shadowsocks.Test
                     "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388",
                     "\r\n",
                     "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388/",
-                    "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388#example-server",
-                    "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388/#example-server",
+                    "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388#example-server+2",
+                    "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388/#example-server+2",
                     server2WithPluginCanonUrl,
                     server2WithPluginAndRemarkCanonUrl,
-                    "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com&unsupported=1#example-server"),
+                    "ss://YmYtY2ZiOnRlc3Q@192.168.1.1:8388/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com&unsupported=1#example-server+2"),
                 new[]
                 {
                     server2,


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio
- [ ] Require translation update
- [ ] Require document update (readme.md, wikipage, etc)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

Current implementation of SIP002 URI Scheme parser produces wrong output for a URI with spaces in its `fragment` section.

#### Expected Behavior
Given URI `ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com#example-server+1`, a `Server` with remark `example-server 1` is created.

#### Current Behavior
Given URI `ss://YmYtY2ZiOnRlc3Q@192.168.100.1:8888/?plugin=obfs-local%3bobfs%3dhttp%3bobfs-host%3dgoogle.com#example-server+1`, a `Server` with remark `example-server+1` is created.

### Note
Current behavior was also observed in other SIP002 implementations, such as Shadowrocket. This fix may break potential compatibility with these clients.