### PR TITLE
OnlineConfigResolver: add User-Agent

### DIFF
--- a/shadowsocks-csharp/Controller/Service/GeositeUpdater.cs
+++ b/shadowsocks-csharp/Controller/Service/GeositeUpdater.cs
@@ -102,6 +102,8 @@ namespace Shadowsocks.Controller
             // because we can't change proxy on existing socketsHttpHandler instance
             httpClientHandler = new HttpClientHandler();
             httpClient = new HttpClient(httpClientHandler);
+            if (!string.IsNullOrWhiteSpace(config.userAgentString))
+                httpClient.DefaultRequestHeaders.Add("User-Agent", config.userAgentString);
             if (config.enabled)
             {
                 httpClientHandler.Proxy = new WebProxy(

--- a/shadowsocks-csharp/Controller/Service/OnlineConfigResolver.cs
+++ b/shadowsocks-csharp/Controller/Service/OnlineConfigResolver.cs
@@ -22,6 +22,9 @@ namespace Shadowsocks.Controller.Service
                 Timeout = TimeSpan.FromSeconds(15)
             };
 
+            string userAgent = "ShadowsocksWindows/" + UpdateChecker.Version;
+            httpClient.DefaultRequestHeaders.Add("User-Agent", userAgent);
+
             string server_json = await httpClient.GetStringAsync(url);
 
             var servers = server_json.GetServers();

--- a/shadowsocks-csharp/Controller/Service/OnlineConfigResolver.cs
+++ b/shadowsocks-csharp/Controller/Service/OnlineConfigResolver.cs
@@ -11,7 +11,7 @@ namespace Shadowsocks.Controller.Service
 {
     public class OnlineConfigResolver
     {
-        public static async Task<List<Server>> GetOnline(string url, IWebProxy proxy = null)
+        public static async Task<List<Server>> GetOnline(string url, string userAgentString, IWebProxy proxy = null)
         {
             var httpClientHandler = new HttpClientHandler()
             {
@@ -21,9 +21,8 @@ namespace Shadowsocks.Controller.Service
             {
                 Timeout = TimeSpan.FromSeconds(15)
             };
-
-            string userAgent = "ShadowsocksWindows/" + UpdateChecker.Version;
-            httpClient.DefaultRequestHeaders.Add("User-Agent", userAgent);
+            if (!string.IsNullOrWhiteSpace(userAgentString))
+                httpClient.DefaultRequestHeaders.Add("User-Agent", userAgentString);
 
             string server_json = await httpClient.GetStringAsync(url);
 

--- a/shadowsocks-csharp/Controller/ShadowsocksController.cs
+++ b/shadowsocks-csharp/Controller/ShadowsocksController.cs
@@ -691,7 +691,7 @@ namespace Shadowsocks.Controller
 
         public async Task<int> UpdateOnlineConfigInternal(string url)
         {
-            var onlineServer = await OnlineConfigResolver.GetOnline(url, _config.WebProxy);
+            var onlineServer = await OnlineConfigResolver.GetOnline(url, _config.userAgentString, _config.WebProxy);
             _config.configs = Configuration.SortByOnlineConfig(
                 _config.configs
                 .Where(c => c.group != url)

--- a/shadowsocks-csharp/Model/Configuration.cs
+++ b/shadowsocks-csharp/Model/Configuration.cs
@@ -46,6 +46,7 @@ namespace Shadowsocks.Model
         public string geositeUrl; // for custom geosite source (and rule group)
         public string geositeGroup;
         public bool geositeBlacklistMode;
+        public string userAgent;
 
         //public NLogConfig.LogLevel logLevel;
         public LogViewerConfig logViewer;
@@ -81,6 +82,7 @@ namespace Shadowsocks.Model
             geositeUrl = "";
             geositeGroup = "geolocation-!cn";
             geositeBlacklistMode = true;
+            userAgent = "ShadowsocksWindows/$version";
 
             logViewer = new LogViewerConfig();
             proxy = new ProxyConfig();
@@ -91,6 +93,9 @@ namespace Shadowsocks.Model
             configs = new List<Server>();
             onlineConfigSource = new List<string>();
         }
+
+        [JsonIgnore]
+        public string userAgentString; // $version substituted with numeral version in it
 
         [JsonIgnore]
         NLogConfig nLogConfig;
@@ -153,6 +158,7 @@ namespace Shadowsocks.Model
                 string configContent = File.ReadAllText(CONFIG_FILE);
                 config = JsonConvert.DeserializeObject<Configuration>(configContent);
                 config.isDefault = false;
+                config.version = UpdateChecker.Version;
                 if (UpdateChecker.Asset.CompareVersion(UpdateChecker.Version, config.version ?? "0") > 0)
                 {
                     config.updated = true;
@@ -200,6 +206,8 @@ namespace Shadowsocks.Model
                 // todo: route the error to UI since there is no log file in this scenario
                 logger.Error(e, "Cannot get the log level from NLog config file. Please check if the nlog config file exists with corresponding XML nodes.");
             }
+
+            config.userAgentString = config.userAgent.Replace("$version", config.version);
 
             return config;
         }


### PR DESCRIPTION
Signed-off-by: Beta Soft <betaxab@gmail.com>

## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio
- [ ] Require translation update
- [ ] Require document update (readme.md, wikipage, etc)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

Explanation of your *pull request* in arbitrary form goes here. Please make sure the description explains the purpose and effect of your *pull request* and is worded well enough to be understood. Provide as much context and examples as possible.

User-Agent should be added to `httpClient` to get online configuration.
Use the shadowsocks-windows owns name  `ShadowsocksWindows/{UpdateChecker.Version}` instand of Web Browser default UA should be better, help online configuration API determine the client type.
