### PR TITLE
🎃 PAC: workaround to exempt private IP ranges in whitelist mode

### DIFF
--- a/shadowsocks-csharp/Data/abp.js
+++ b/shadowsocks-csharp/Data/abp.js
@@ -793,7 +793,22 @@ for (var i = 0; i < rules.length; i++) {
     defaultMatcher.add(Filter.fromText(rules[i]));
 }
 
+// PAC has no v6 support, it sucks
+var ip4Re = /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/
+
+var privateNet = [
+    ["10.0.0.0", "255.0.0.0"],
+    ["127.0.0.0", "255.0.0.0"],
+    ["172.16.0.0", "255.240.0.0"],
+    ["192.168.0.0", "255.255.0.0"],
+]
+
 function FindProxyForURL(url, host) {
+    if (host.match(ip4Re)) {
+        for (var i = 0; i < privateNet.length; i++) {
+            if (isInNet(host, privateNet[i][0], privateNet[i][1])) return direct;
+        }
+    }
     if (userrulesMatcher.matchesAny(url, host) instanceof BlockingFilter) {
         return proxy;
     }


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

- [x] [Searched](https://github.com/shadowsocks/shadowsocks-windows/search?q=is%3Apr&type=Issues) for similar pull requests
- [x] Compiled the code with Visual Studio
- [ ] Require translation update
- [ ] Require document update (readme.md, wikipage, etc)

### What is the purpose of your *pull request*?
- [ ] Bug fix
- [x] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

- Could match domains with similar patterns. But that's all we can do for now.
- No active developers use PAC mode. We are looking to deprecate PAC in favor of routing solutions.
- Closes #3002.